### PR TITLE
#1 layout: 首頁Header 切版 

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
+import HeaderNavbar from './components/HeaderNavbar.vue';
 import Home from './components/Home.vue'
 </script>
 
 <template>
+  <HeaderNavbar />
   <Home />
 </template>
 

--- a/src/components/HeaderNavbar.vue
+++ b/src/components/HeaderNavbar.vue
@@ -1,0 +1,7 @@
+<script setup lang="ts">
+const emit = defineEmits<{
+  (e: "login"): void
+  (e: "signup"): void
+}>()
+</script>
+

--- a/src/components/HeaderNavbar.vue
+++ b/src/components/HeaderNavbar.vue
@@ -5,3 +5,19 @@ const emit = defineEmits<{
 }>()
 </script>
 
+<template>
+  <nav class="fixed top-0 left-0 right-0 z-50 bg-white shadow-md">
+    <div class="max-w-[1440px] mx-auto px-[5%] sm:px-[8%] lg:px-[5%]">
+      <div class="flex justify-between items-center h-[60px] sm:h-[70px]">
+        <!-- logo佔位區 -->
+        <a href="/" class="flex items-center gap-2">
+          <i class="fa-solid fa-car text-[#6b6b5a] text-[20px] sm:text-[24px]"></i>
+          <span class="text-[20px] sm:text-[24px] font-bold text-[#4a4a43]">carE</span>
+        </a>
+        <div class="flex items-center gap-2 sm:gap-3">
+
+        </div>
+      </div>
+    </div>
+  </nav>
+</template>

--- a/src/components/HeaderNavbar.vue
+++ b/src/components/HeaderNavbar.vue
@@ -1,13 +1,14 @@
 <script setup lang="ts">
-const emit = defineEmits<{
-  (e: "login"): void
-  (e: "signup"): void
+defineEmits<{
+  (e: 'login'): void
+  (e: 'signup'): void
 }>()
+const baseButtonClass = 'px-3 py-3 sm:px-4 sm:py-2 lg:px-5 lg:py-2 text-[14px] sm:text-[15px] lg:text-[16px] rounded-lg sm:rounded-xl transition-colors duration-200'
 </script>
 
 <template>
-  <nav class="fixed top-0 left-0 right-0 z-50 bg-white shadow-md">
-    <div class="max-w-[1440px] mx-auto px-[5%] sm:px-[8%] lg:px-[5%]">
+  <header class="fixed top-0 left-0 right-0 z-50 bg-white shadow-md">
+    <nav class="max-w-[1440px] mx-auto px-[5%] sm:px-[8%] lg:px-[5%]">
       <div class="flex justify-between items-center h-[60px] sm:h-[70px]">
         <!-- logo佔位區 -->
         <a href="/" class="flex items-center gap-2">
@@ -15,9 +16,20 @@ const emit = defineEmits<{
           <span class="text-[20px] sm:text-[24px] font-bold text-[#4a4a43]">carE</span>
         </a>
         <div class="flex items-center gap-2 sm:gap-3">
-
+          <button
+            @click="$emit('login')"
+            :class="[baseButtonClass, 'border border-[#6b6b5a] text-[#6b6b5a] hover:bg-[#6b6b5a] hover:text-white']"
+          >
+          登入
+          </button>
+          <button
+            @click="$emit('signup')"
+            :class="[baseButtonClass, 'bg-[#6b6b5a] text-white hover:bg-[#5a5a4a] px-4 sm:px-6 lg:px-6 font-medium border border-transparent']"
+          >
+          加入會員
+          </button>
         </div>
       </div>
-    </div>
-  </nav>
+    </nav>
+  </header>
 </template>

--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -1,0 +1,5 @@
+<template>
+
+
+    
+</template>

--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -3,8 +3,16 @@
     <nav class="fixed top-0 z-1">
       navbar 佔位區
       <div class="logo"></div>
-      <div class="menu"></div>
-      <div class="member"></div>
+      <div class="login">
+        <button>
+          會員登入
+        </button>
+      </div>
+      <div class="register">
+        <button>
+          加入會員
+        </button>
+      </div>
     </nav>
-  </header>    
+  </header>
 </template>

--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -1,5 +1,10 @@
 <template>
-
-
-    
+  <header class="relative bg-red-50">
+    <nav class="fixed top-0 z-1">
+      navbar 佔位區
+      <div class="logo"></div>
+      <div class="menu"></div>
+      <div class="member"></div>
+    </nav>
+  </header>    
 </template>


### PR DESCRIPTION
完成HeaderNavbar 切版 
logo區先以icon+文字暫放

並在App.vue import 讓畫面顯示

<img width="1446" height="628" alt="截圖 2025-12-28 清晨6 08 16" src="https://github.com/user-attachments/assets/f04928a0-9bc4-4de2-8d68-f0f8159cdd32" />
<img width="215" height="415" alt="截圖 2025-12-28 清晨6 08 33" src="https://github.com/user-attachments/assets/63431c29-db97-48ad-82a7-976ca28bbf7d" />
<img width="403" height="478" alt="截圖 2025-12-28 清晨6 09 26" src="https://github.com/user-attachments/assets/3bc36d56-1820-43de-a695-f2eac238bd43" />
