### PR TITLE
#14 維修廠預約流程

### DIFF
--- a/src/components/BookingTimeSelectorView.vue
+++ b/src/components/BookingTimeSelectorView.vue
@@ -1,0 +1,138 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { DatePicker } from 'v-calendar'
+import 'v-calendar/style.css'
+
+const props = defineProps<{
+  date: Date | null
+  time: string | null
+}>()
+
+const emits = defineEmits<{
+  (e: 'update:date', val: Date | null): void
+  (e: 'update:time', val: string | null): void
+}>()
+
+const selectedDate = computed({
+  get: () => props.date,
+  set: (val) => emits('update:date', val),
+})
+
+const localTime = computed({
+  get: () => props.time,
+  set: (val) => emits('update:time', val),
+})
+
+const today: Date = new Date()
+
+const formattedDate = computed<string | null>(() => {
+  if (!selectedDate.value) return null
+  return selectedDate.value.toLocaleDateString('zh-TW', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    weekday: 'long',
+  })
+})
+
+// TODO: API串接
+const buttons = [
+  { time: '09:00 早上', status: '剩餘 3' },
+  { time: '10:00 早上', status: '剩餘 3' },
+  { time: '11:00 早上', status: '剩餘 3' },
+  { time: '13:00 下午', status: '已額滿' },
+]
+
+const setActive = (btnTime: string, status: string) => {
+  if (status === '已額滿') return
+  localTime.value = btnTime
+}
+</script>
+
+<template>
+  <div class="w-full">
+    <h2 class="mb-6 text-[20px] text-[#3a3a38] font-bold">選擇日期與時段</h2>
+    <section class="flex flex-wrap justify-between gap-8 md:flex-nowrap">
+      <div class="w-full md:w-[45%]">
+        <DatePicker
+          v-model="selectedDate"
+          :min-date="today"
+          expanded
+          borderless
+          transparent
+          class="w-full rounded-[16px] border border-[#E6E6DF] bg-white p-4"
+          :attributes="[
+            {
+              key: 'today',
+              highlight: {
+                color: 'gray',
+                fillMode: 'light',
+              },
+              dates: new Date(),
+            },
+          ]"
+        />
+      </div>
+      <div class="flex w-full flex-col md:w-[55%]">
+        <div class="mb-6 rounded-[16px] border border-[#E6E6DF] bg-[#FBFBFA] p-5">
+          <div v-if="!formattedDate" class="flex flex-col items-center justify-center py-4">
+            <i class="fa-regular fa-calendar text-[40px] text-[#D1D1CB]"></i>
+            <p class="mt-3 text-[14px] text-[#8A8A86]">請先選擇日期</p>
+          </div>
+          <div v-else class="flex items-start gap-3">
+            <i class="fa-regular fa-calendar mt-1 text-[24px] text-[#6B6B5C]"></i>
+            <div>
+              <div class="text-[18px] font-bold text-[#3A3A38]">{{ formattedDate }}</div>
+              <div v-if="localTime" class="mt-1 text-[16px] font-bold text-[#6B6B5C]">{{ localTime }}</div>
+              <div v-else class="mt-1 text-[14px] text-[#8A8A86]">請選擇下方時段</div>
+            </div>
+          </div>
+        </div>
+        <div>
+          <p class="mb-3 text-[14px] font-bold text-[#8A8A86]">選擇時段</p>
+          <div
+            class="rounded-[16px] border border-[#E6E6DF] p-4 transition-colors"
+            :class="{ 'bg-[#FBFBFA]': !formattedDate }"
+          >
+            <div v-if="!formattedDate" class="flex flex-col items-center justify-center py-8">
+              <i class="fa-regular fa-clock text-[40px] text-[#D1D1CB]"></i>
+              <p class="mt-3 text-[14px] text-[#8A8A86]">請先選擇日期以查看時段</p>
+            </div>
+            <div v-else class="flex flex-col gap-3">
+              <button
+                v-for="btn in buttons"
+                :key="btn.time"
+                type="button"
+                @click="setActive(btn.time, btn.status)"
+                :disabled="btn.status === '已額滿'"
+                class="group flex w-full items-center justify-between rounded-[12px] border p-4 text-left transition-all"
+                :class="[
+                  btn.status === '已額滿'
+                    ? 'cursor-not-allowed border-[#E6E6DF] bg-[#F5F5F0] text-[#B5B5AD]'
+                    : localTime === btn.time
+                      ? 'border-[#6B6B5C] bg-[#6B6B5C] text-white shadow-md'
+                      : 'border-[#E6E6DF] bg-white text-[#3A3A38] hover:border-[#B5B5AD] hover:shadow-sm',
+                ]"
+              >
+                <div class="flex items-center gap-3">
+                  <i
+                    class="fa-regular fa-clock text-lg"
+                    :class="[
+                      localTime === btn.time
+                        ? 'text-white'
+                        : btn.status === '已額滿'
+                          ? 'text-[#B5B5AD]'
+                          : 'text-[#6B6B5C]',
+                    ]"
+                  ></i>
+                  <span class="text-[16px] font-bold">{{ btn.time }}</span>
+                </div>
+                <span class="text-[13px] font-medium opacity-90">{{ btn.status }}</span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+    </div>
+</template>

--- a/src/components/ServiceSearch.vue
+++ b/src/components/ServiceSearch.vue
@@ -1,0 +1,1 @@
+<template></template>

--- a/src/components/ServiceSearch.vue
+++ b/src/components/ServiceSearch.vue
@@ -32,13 +32,11 @@ const serviceOptions = [
 				</div>
 			</div>
 			<div class="flex items-center gap-4">
-				<button class="px-4 py-2 text-sm font-medium text-white transition-colors rounded bg-[#6b635c] hover:bg-[#5a534d]">預約服務
-				</button>
-				<button class="text-sm font-medium text-gray-600 transition-colors hover:text-gray-900">我的預約
-				</button>
+				<button class="px-4 py-2 text-sm font-medium text-white transition-colors rounded bg-[#6b635c] hover:bg-[#5a534d]">預約服務</button>
+				<button class="text-sm font-medium text-gray-600 transition-colors hover:text-gray-900">我的預約</button>
 				<button class="flex items-center gap-2 px-4 py-2 text-sm text-white rounded bg-[#6b635c]">
 					<i class="fa-solid fa-check"></i>
-					開發模式
+                    開發模式
 				</button>
 			</div>
 		</header>
@@ -46,19 +44,14 @@ const serviceOptions = [
 			<div class="flex flex-col p-10 bg-white shadow-lg rounded-2xl min-h-[600px]">
 				<div class="relative flex justify-between w-full px-12 mb-12">
 					<div class="absolute top-5 left-0 right-0 w-full h-[2px] bg-gray-200 -z-10 translate-y-[-50%] mx-auto max-w-[90%]"></div>
-					<div 
-						v-for="s in steps" 
-						:key="s.step"
-						class="flex flex-col items-center gap-3 bg-white"
-					>
-						<div 
-							class="flex items-center justify-center w-10 h-10 text-sm font-bold transition-all border-2 rounded-full"
+					<div v-for="s in steps" :key="s.step" class="flex flex-col items-center gap-3 bg-white">
+						<div class="flex items-center justify-center w-10 h-10 text-sm font-bold transition-all border-2 rounded-full"
 							:class="[
 								currentStep === s.step 
 									? `bg-[#6b635c] border-[#6b635c] text-white` 
 									: `bg-white border-gray-300 text-gray-400`
-							]"
-						>
+                                    ]"
+                        >
 							{{ s.step }}
 						</div>
 						<span 
@@ -92,8 +85,7 @@ const serviceOptions = [
 				<div v-if="currentStep === 1" class="flex-1">
 					<h2 class="mb-6 text-xl font-bold text-gray-800">選擇服務項目</h2>
 					<div class="grid grid-cols-2 gap-6">
-						<div 
-							v-for="service in serviceOptions"
+						<div v-for="service in serviceOptions"
 							:key="service.id"
 							@click="selectedServiceId = service.id"
 							class="flex items-center gap-6 p-6 transition-all border rounded-xl cursor-pointer group hover:shadow-md"
@@ -101,15 +93,15 @@ const serviceOptions = [
 								selectedServiceId === service.id 
 									? `border-[#6b635c] bg-stone-50` 
 									: `border-gray-200 bg-white`
-							]"
-						>
+                                    ]"
+                        >
 							<div 
 								class="flex items-center justify-center w-16 h-16 transition-colors rounded-lg"
 								:class="[
 									selectedServiceId === service.id 
 										? `bg-[#6b635c] text-white` 
 										: `bg-[#6b635c] text-white opacity-80`
-								]"
+                                        ]"
 							>
 								<i class="text-2xl fa-solid" :class="service.icon"></i>
 							</div>
@@ -125,7 +117,7 @@ const serviceOptions = [
 					<p>步驟 {{ currentStep }} 內容建置中...</p>
 				</div>
 				<div class="flex justify-between mt-12 pt-6 border-t border-gray-100">
-					<button 
+                    <button 
 						@click="currentStep > 1 ? currentStep-- : null"
 						:disabled="currentStep === 1"
 						class="px-8 py-3 text-sm font-medium transition-colors border border-gray-200 rounded disabled:opacity-50 disabled:cursor-not-allowed hover:bg-gray-50 text-gray-500">

--- a/src/components/ServiceSearch.vue
+++ b/src/components/ServiceSearch.vue
@@ -20,6 +20,7 @@ const serviceOptions = [
 </script>
 
 <template>
+	<!--新年快樂-->
 	<div class="flex flex-col min-h-screen bg-[#f9f9f9] text-[#4a4a4a] font-sans">
 		<header class="flex justify-between items-center px-8 py-4 bg-white border-b border-gray-100">
 			<div class="flex items-center gap-4">

--- a/src/components/ServiceSearch.vue
+++ b/src/components/ServiceSearch.vue
@@ -1,1 +1,90 @@
-<template></template>
+<template>
+	<div class="min-h-screen bg-[#faf9f7]">
+		<nav class="border-b border-[#ede9e4] bg-white">
+			<div class="mx-auto flex h-16 max-w-[1200px] items-center justify-between px-4">
+				<div class="flex items-center gap-3">
+					<div class="flex h-10 w-10 items-center justify-center rounded-lg bg-[#8b7e6b] text-white">
+						<i class="fa-solid fa-calendar"></i>
+					</div>
+					<div>
+						<p class="text-base font-semibold text-[#3f3a34]">職人維修工房</p>
+						<p class="text-sm text-[#8b8378]">專業維修・值得信賴</p>
+					</div>
+				</div>
+				<div class="hidden items-center gap-3 md:flex">
+					<button type="button" class="rounded-lg bg-[#8b7e6b] px-4 py-2 text-sm text-white">預約服務</button>
+					<button type="button" class="rounded-lg border border-[#d6d0c8] px-4 py-2 text-sm text-[#3f3a34]">我的預約</button>
+					<button type="button" class="rounded-lg bg-[#6f665a] px-4 py-2 text-sm text-white">✓ 開發模式</button>
+				</div>
+			</div>
+		</nav>
+		<main class="mx-auto max-w-[1200px] px-4 py-8">
+			<section class="mb-8 hidden md:block">
+				<div class="flex items-center justify-between">
+					<div v-for="step in 5" :key="step" class="flex flex-1 items-center">
+						<div class="flex flex-col items-center">
+							<div :class="[
+									'flex h-8 w-8 items-center justify-center rounded-full text-sm',
+									step === 1
+										? 'bg-[#8b7e6b] text-white'
+										: 'border border-[#d6d0c8] text-[#8b8378]'
+								]">
+								{{ step }}
+							</div>
+							<p class="mt-2 text-sm text-[#6f665a]">
+								{{ ['選擇服務','車輛類型','選擇日期','選擇時段','確認預約'][step - 1] }}
+							</p>
+						</div>
+						<div v-if="step !== 5" class="mx-2 h-px flex-1 bg-[#ede9e4]"></div>
+					</div>
+				</div>
+			</section>
+			<!-- Dev Mode -->
+			<section class="mb-10 rounded-xl border border-[#ede9e4] bg-white p-6">
+				<p class="mb-4 text-sm text-[#6f665a]">開發者模式・快速切換步驟：</p>
+				<div class="mb-6 flex flex-wrap gap-2">
+					<button
+						v-for="item in ['選擇服務','車輛類型','選擇日期','選擇時段','確認預約']"
+						:key="item"
+						type="button"
+						class="rounded-lg border border-[#d6d0c8] px-4 py-2 text-sm text-[#3f3a34]"
+					>
+						{{ item }}
+					</button>
+				</div>
+				<button type="button" class="rounded-lg bg-[#d6d0c8] px-4 py-2 text-sm text-[#3f3a34]">填充所有欄位</button>
+			</section>
+			<section>
+				<h2 class="mb-6 text-xl font-semibold text-[#3f3a34]">選擇服務項目</h2>
+				<div class="grid gap-6 md:grid-cols-2">
+					<div
+						v-for="service in [
+							{ icon: 'wrench', title: '機油更換', time: '30分鐘' },
+							{ icon: 'car', title: '輪胎檢修', time: '45分鐘' },
+							{ icon: 'circle-check', title: '煞車系統檢查', time: '60分鐘' },
+							{ icon: 'wrench', title: '定期保養', time: '90分鐘' }
+						]"
+						:key="service.title"
+						class="flex items-center gap-4 rounded-xl border border-[#ede9e4] bg-white p-6"
+					>
+						<div class="flex h-12 w-12 items-center justify-center rounded-lg bg-[#f3f1ee] text-[#6f665a]">
+							<i :class="`fa-solid fa-${service.icon}`"></i>
+						</div>
+						<div>
+							<p class="text-base font-semibold text-[#3f3a34]">
+								{{ service.title }}
+							</p>
+							<p class="text-sm text-[#8b8378]">
+								預估時間：{{ service.time }}
+							</p>
+						</div>
+					</div>
+				</div>
+				<div class="mt-10 flex items-center justify-between">
+					<button type="button" class="rounded-lg border border-[#d6d0c8] px-6 py-2 text-sm text-[#8b8378]">上一步</button>
+					<button type="button" class="rounded-lg bg-[#b7afa5] px-6 py-2 text-sm text-white">下一步</button>
+				</div>
+			</section>
+		</main>
+	</div>
+</template>

--- a/src/components/ServiceSearch.vue
+++ b/src/components/ServiceSearch.vue
@@ -3,134 +3,122 @@ import { ref } from 'vue';
 
 const currentStep = ref<number>(1);
 const selectedServiceId = ref<string>("");
+
 const steps = [
-	{ step: 1, label: `選擇服務` },
-	{ step: 2, label: `車輛類型` },
-	{ step: 3, label: `選擇日期` },
-	{ step: 4, label: `選擇時段` },
-	{ step: 5, label: `確認預約` },
+  { step: 1, label: '選擇服務' },
+  { step: 2, label: '車輛類型' },
+  { step: 3, label: '選擇日期' },
+  { step: 4, label: '選擇時段' },
+  { step: 5, label: '確認預約' },
 ];
 
 const serviceOptions = [
-	{ id: `oil-change`, title: `機油更換`, duration: `30分鐘`, icon: `fa-wrench` },
-	{ id: `tire-check`, title: `輪胎檢修`, duration: `45分鐘`, icon: `fa-car` },
-	{ id: `brake-check`, title: `煞車系統檢查`, duration: `60分鐘`, icon: `fa-shield-halved` },
-	{ id: `maintenance`, title: `定期保養`, duration: `90分鐘`, icon: `fa-screwdriver-wrench` },
+  { id: 'oil-change', title: '機油更換', duration: '30分鐘', icon: 'fa-wrench' },
+  { id: 'tire-check', title: '輪胎檢修', duration: '45分鐘', icon: 'fa-car' },
+  { id: 'brake-check', title: '煞車系統檢查', duration: '60分鐘', icon: 'fa-shield-halved' },
+  { id: 'maintenance', title: '定期保養', duration: '90分鐘', icon: 'fa-screwdriver-wrench' },
 ];
 </script>
 
 <template>
-	<!--新年快樂-->
-	<div class="flex flex-col min-h-screen bg-[#f9f9f9] text-[#4a4a4a] font-sans">
-		<header class="flex justify-between items-center px-8 py-4 bg-white border-b border-gray-100">
-			<div class="flex items-center gap-4">
-				<div class="flex items-center justify-center w-10 h-10 text-white rounded bg-[#6b635c]">
-					<i class="text-xl fa-regular fa-calendar"></i>
-				</div>
-				<div>
-					<h1 class="text-lg font-bold tracking-wide text-gray-800">職人維修工房</h1>
-					<p class="text-xs text-gray-500">專業維修・值得信賴</p>
-				</div>
-			</div>
-			<div class="flex items-center gap-4">
-				<button class="px-4 py-2 text-sm font-medium text-white transition-colors rounded bg-[#6b635c] hover:bg-[#5a534d]">預約服務</button>
-				<button class="text-sm font-medium text-gray-600 transition-colors hover:text-gray-900">我的預約</button>
-				<button class="flex items-center gap-2 px-4 py-2 text-sm text-white rounded bg-[#6b635c]">
-					<i class="fa-solid fa-check"></i>
-                    開發模式
-				</button>
-			</div>
-		</header>
-		<main class="flex-1 w-full max-w-6xl p-8 mx-auto">
-			<div class="flex flex-col p-10 bg-white shadow-lg rounded-2xl min-h-[600px]">
-				<div class="relative flex justify-between w-full px-12 mb-12">
-					<div class="absolute top-5 left-0 right-0 w-full h-[2px] bg-gray-200 -z-10 translate-y-[-50%] mx-auto max-w-[90%]"></div>
-					<div v-for="s in steps" :key="s.step" class="flex flex-col items-center gap-3 bg-white">
-						<div class="flex items-center justify-center w-10 h-10 text-sm font-bold transition-all border-2 rounded-full"
-							:class="[
-								currentStep === s.step 
-									? `bg-[#6b635c] border-[#6b635c] text-white` 
-									: `bg-white border-gray-300 text-gray-400`
-                                    ]"
-                        >
-							{{ s.step }}
-						</div>
-						<span 
-							class="text-sm tracking-wide"
-							:class="currentStep === s.step ? `text-[#6b635c] font-medium` : `text-gray-400`"
-						>
-							{{ s.label }}
-						</span>
-					</div>
-				</div>
-				<div class="p-6 mb-10 border border-gray-100 rounded-lg bg-gray-50">
-					<p class="mb-3 text-sm font-medium text-gray-500">開發者模式 - 快速切換步驟：</p>
-					<div class="flex gap-3 mb-4">
-						<button 
-							v-for="s in steps"
-							:key="`dev-btn-${s.step}`"
-							@click="currentStep = s.step"
-							class="px-4 py-2 text-sm font-bold text-gray-700 transition-colors bg-white border border-gray-300 rounded shadow-sm hover:bg-gray-100"
-							:class="{ '!bg-[#6b635c] !text-white !border-[#6b635c]': currentStep === s.step }"
-						>
-							{{ s.step }}. {{ s.label }}
-						</button>
-					</div>
-					<p class="mb-3 text-sm font-medium text-gray-500">快速填充測試資料：</p>
-					<button 
-						@click="selectedServiceId = `oil-change`"
-						class="px-4 py-2 text-sm font-bold text-gray-600 transition-colors bg-gray-200 rounded hover:bg-gray-300">
-						填充所有欄位
-					</button>
-				</div>
-				<div v-if="currentStep === 1" class="flex-1">
-					<h2 class="mb-6 text-xl font-bold text-gray-800">選擇服務項目</h2>
-					<div class="grid grid-cols-2 gap-6">
-						<div v-for="service in serviceOptions"
-							:key="service.id"
-							@click="selectedServiceId = service.id"
-							class="flex items-center gap-6 p-6 transition-all border rounded-xl cursor-pointer group hover:shadow-md"
-							:class="[
-								selectedServiceId === service.id 
-									? `border-[#6b635c] bg-stone-50` 
-									: `border-gray-200 bg-white`
-                                    ]"
-                        >
-							<div 
-								class="flex items-center justify-center w-16 h-16 transition-colors rounded-lg"
-								:class="[
-									selectedServiceId === service.id 
-										? `bg-[#6b635c] text-white` 
-										: `bg-[#6b635c] text-white opacity-80`
-                                        ]"
-							>
-								<i class="text-2xl fa-solid" :class="service.icon"></i>
-							</div>
-							<div>
-								<h3 class="text-lg font-bold text-gray-800">{{ service.title }}</h3>
-								<p class="text-sm text-gray-500">預估時間：{{ service.duration }}</p>
-							</div>
-						</div>
-					</div>
-				</div>
-				<div v-else class="flex flex-col items-center justify-center flex-1 h-64 text-gray-400 border-2 border-dashed rounded-xl">
-					<i class="mb-4 text-4xl fa-solid fa-person-digging"></i>
-					<p>步驟 {{ currentStep }} 內容建置中...</p>
-				</div>
-				<div class="flex justify-between mt-12 pt-6 border-t border-gray-100">
-                    <button 
-						@click="currentStep > 1 ? currentStep-- : null"
-						:disabled="currentStep === 1"
-						class="px-8 py-3 text-sm font-medium transition-colors border border-gray-200 rounded disabled:opacity-50 disabled:cursor-not-allowed hover:bg-gray-50 text-gray-500">
-						上一步
-					</button>
-					<button 
-						@click="currentStep < 5 ? currentStep++ : null"
-						class="px-8 py-3 text-sm font-medium text-white transition-colors rounded shadow-md bg-[#6b635c] hover:bg-[#5a534d]">
-						下一步
-					</button>
-				</div>
-			</div>
-		</main>
-	</div>
+  <div class="flex flex-col min-h-screen bg-[#f9f9f9] text-[#4a4a4a] font-sans">
+    <main class="flex-1 w-full max-w-6xl p-8 mx-auto">
+      <div class="flex flex-col p-10 bg-white shadow-lg rounded-2xl min-h-[600px]">
+
+        <!-- Step Indicator -->
+        <div class="relative flex justify-between w-full px-12 mb-12">
+          <div
+            class="absolute top-5 left-0 right-0 w-full h-[2px] bg-gray-200 -z-10 translate-y-[-50%] mx-auto max-w-[90%]"
+          />
+          <div
+            v-for="s in steps"
+            :key="s.step"
+            class="flex flex-col items-center gap-3 bg-white"
+          >
+            <div
+              class="flex items-center justify-center w-10 h-10 text-sm font-bold transition-all border-2 rounded-full"
+              :class="currentStep === s.step
+                ? 'bg-[#6b635c] border-[#6b635c] text-white'
+                : 'bg-white border-gray-300 text-gray-400'"
+            >
+              {{ s.step }}
+            </div>
+            <span
+              class="text-sm tracking-wide"
+              :class="currentStep === s.step
+                ? 'text-[#6b635c] font-medium'
+                : 'text-gray-400'"
+            >
+              {{ s.label }}
+            </span>
+          </div>
+        </div>
+
+        <!-- Step 1 -->
+        <div v-if="currentStep === 1" class="flex-1">
+          <h2 class="mb-6 text-xl font-bold text-gray-800">
+            選擇服務項目
+          </h2>
+
+          <div class="grid grid-cols-2 gap-6">
+            <div
+              v-for="service in serviceOptions"
+              :key="service.id"
+              @click="selectedServiceId = service.id"
+              class="flex items-center gap-6 p-6 transition-all border rounded-xl cursor-pointer hover:shadow-md"
+              :class="selectedServiceId === service.id
+                ? 'border-[#6b635c] bg-stone-50'
+                : 'border-gray-200 bg-white'"
+            >
+              <div
+                class="flex items-center justify-center w-16 h-16 rounded-lg"
+                :class="selectedServiceId === service.id
+                  ? 'bg-[#6b635c] text-white'
+                  : 'bg-[#6b635c] text-white opacity-80'"
+              >
+                <i class="text-2xl fa-solid" :class="service.icon"></i>
+              </div>
+
+              <div>
+                <h3 class="text-lg font-bold text-gray-800">
+                  {{ service.title }}
+                </h3>
+                <p class="text-sm text-gray-500">
+                  預估時間：{{ service.duration }}
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Other Steps Placeholder -->
+        <div
+          v-else
+          class="flex flex-col items-center justify-center flex-1 h-64 text-gray-400 border-2 border-dashed rounded-xl"
+        >
+          <i class="mb-4 text-4xl fa-solid fa-person-digging"></i>
+          <p>步驟 {{ currentStep }} 內容建置中...</p>
+        </div>
+
+        <!-- Navigation -->
+        <div class="flex justify-between mt-12 pt-6 border-t border-gray-100">
+          <button
+            @click="currentStep > 1 && currentStep--"
+            :disabled="currentStep === 1"
+            class="px-8 py-3 text-sm font-medium transition-colors border border-gray-200 rounded disabled:opacity-50 disabled:cursor-not-allowed hover:bg-gray-50 text-gray-500"
+          >
+            上一步
+          </button>
+
+          <button
+            @click="currentStep < 5 && currentStep++"
+            class="px-8 py-3 text-sm font-medium text-white transition-colors rounded shadow-md bg-[#6b635c] hover:bg-[#5a534d]"
+          >
+            下一步
+          </button>
+        </div>
+
+      </div>
+    </main>
+  </div>
 </template>

--- a/src/components/ServiceSearch.vue
+++ b/src/components/ServiceSearch.vue
@@ -22,15 +22,7 @@
                 :class="circleClass(idx + 1)"
               >
                 <template v-if="idx + 1 < step">
-                  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-                    <path
-                      d="M20 6L9 17l-5-5"
-                      stroke="white"
-                      stroke-width="2.5"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                    />
-                  </svg>
+                  <i class="fa-solid fa-check text-[14px]" aria-hidden="true"></i>
                 </template>
                 <template v-else>
                   {{ idx + 1 }}
@@ -43,10 +35,8 @@
           </div>
         </div>
         <div class="mt-16">
-          <!-- Step 1 -->
           <div v-if="step === 1">
             <h2 class="text-3xl font-bold tracking-tight">選擇服務項目</h2>
-
             <div class="mt-10 grid grid-cols-2 gap-6">
               <button
                 v-for="item in serviceOptions"
@@ -56,10 +46,9 @@
                 :class="serviceCardClass(item.key)"
                 @click="selectedService = item.key"
               >
-                <div class="grid h-14 w-14 place-items-center rounded-2xl bg-[#F5F4EF]">
-                  <span class="text-xl">{{ item.icon }}</span>
+                <div class="grid h-14 w-14 place-items-center rounded-2xl bg-[#F5F4EF] text-[#6E6E6A]">
+                  <i :class="item.fa" class="text-xl" aria-hidden="true"></i>
                 </div>
-
                 <div class="min-w-0">
                   <div class="text-lg font-semibold">{{ item.title }}</div>
                   <div class="mt-1 text-sm text-[#7A7A7A]">預估時間：{{ item.minutes }}分鐘</div>
@@ -67,11 +56,8 @@
               </button>
             </div>
           </div>
-
-          <!-- Step 2 -->
           <div v-else-if="step === 2">
             <h2 class="text-3xl font-bold tracking-tight">選擇車輛類型</h2>
-
             <div class="mt-10 grid grid-cols-2 gap-6">
               <button
                 v-for="v in vehicleOptions"
@@ -87,7 +73,6 @@
                 >
                   <span v-if="selectedVehicle === v.key" class="h-2.5 w-2.5 rounded-full bg-[#6E6E6A]" />
                 </span>
-
                 <div>
                   <div class="text-lg font-semibold">{{ v.title }}</div>
                   <div class="mt-1 text-sm text-[#7A7A7A]">{{ v.subtitle }}</div>
@@ -95,13 +80,9 @@
               </button>
             </div>
           </div>
-
-          <!-- Step 3 -->
           <div v-else-if="step === 3">
             <h2 class="text-3xl font-bold tracking-tight">選擇日期</h2>
-
             <div class="mt-10 grid grid-cols-2 gap-8">
-              <!-- Left: Calendar card -->
               <div class="rounded-2xl border border-[#E6E6DF] bg-white p-8">
                 <div class="flex items-center justify-center gap-4">
                   <button
@@ -110,9 +91,8 @@
                     @click="prevMonth"
                     aria-label="prev month"
                   >
-                    ‹
+                    <i class="fa-solid fa-chevron-left text-sm" aria-hidden="true"></i>
                   </button>
-
                   <div class="flex items-center gap-3">
                     <div class="relative">
                       <select
@@ -121,9 +101,10 @@
                       >
                         <option v-for="y in yearOptions" :key="y" :value="y">{{ y }}年</option>
                       </select>
-                      <span class="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-[#7A7A7A]">▾</span>
+                      <span class="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-[#7A7A7A]"
+                        >▾</span
+                      >
                     </div>
-
                     <div class="relative">
                       <select
                         v-model.number="viewMonth"
@@ -131,24 +112,23 @@
                       >
                         <option v-for="(m, idx) in monthOptions" :key="m" :value="idx">{{ m }}</option>
                       </select>
-                      <span class="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-[#7A7A7A]">▾</span>
+                      <span class="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-[#7A7A7A]"
+                        >▾</span
+                      >
                     </div>
                   </div>
-
                   <button
                     type="button"
                     class="grid h-10 w-10 place-items-center rounded-xl bg-[#F5F4EF] text-lg text-[#6E6E6A] hover:opacity-90"
                     @click="nextMonth"
                     aria-label="next month"
                   >
-                    ›
+                    <i class="fa-solid fa-chevron-right text-sm" aria-hidden="true"></i>
                   </button>
                 </div>
-
                 <div class="mt-10 grid grid-cols-7 gap-4 text-center text-sm font-semibold text-[#6E6E6A]">
                   <div v-for="d in weekDaysMon" :key="d">{{ d }}</div>
                 </div>
-
                 <div class="mt-6 grid grid-cols-7 gap-4 text-center">
                   <button
                     v-for="cell in calendarCellsMon42"
@@ -162,22 +142,12 @@
                   </button>
                 </div>
               </div>
-
-              <!-- Right: Summary + Times -->
               <div class="space-y-6">
                 <div class="rounded-2xl border border-[#E6E6DF] bg-white px-6 py-5">
                   <div class="flex items-start gap-4">
                     <div class="mt-0.5 text-[#6E6E6A]">
-                      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-                        <path
-                          d="M8 2v3M16 2v3M3.5 9h17M6 5h12a2 2 0 0 1 2 2v13a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V7a2 2 0 0 1 2-2z"
-                          stroke="currentColor"
-                          stroke-width="2"
-                          stroke-linecap="round"
-                        />
-                      </svg>
+                      <i class="fa-regular fa-calendar text-xl" aria-hidden="true"></i>
                     </div>
-
                     <div class="min-w-0">
                       <div class="text-lg font-bold">{{ selectedDateLong || "尚未選擇日期" }}</div>
                       <div class="mt-2 text-lg font-semibold text-[#7A7A7A]">
@@ -186,9 +156,7 @@
                     </div>
                   </div>
                 </div>
-
                 <div class="text-sm font-semibold text-[#6E6E6A]">選擇時段</div>
-
                 <div class="rounded-2xl border border-[#E6E6DF] bg-white p-4">
                   <div class="max-h-[320px] overflow-y-auto pr-2">
                     <button
@@ -201,24 +169,19 @@
                     >
                       <div class="flex items-center gap-3">
                         <span :class="selectedTime === t.time ? 'text-white' : 'text-[#6E6E6A]'" class="shrink-0">
-                          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-                            <path d="M12 22a10 10 0 1 0 0-20 10 10 0 0 0 0 20z" stroke="currentColor" stroke-width="2" />
-                            <path
-                              d="M12 6v6l4 2"
-                              stroke="currentColor"
-                              stroke-width="2"
-                              stroke-linecap="round"
-                              stroke-linejoin="round"
-                            />
-                          </svg>
+                          <i class="fa-regular fa-clock text-lg" aria-hidden="true"></i>
                         </span>
-
-                        <div class="text-base font-bold" :class="selectedTime === t.time ? 'text-white' : 'text-[#2B2B2B]'">
+                        <div
+                          class="text-base font-bold"
+                          :class="selectedTime === t.time ? 'text-white' : 'text-[#2B2B2B]'"
+                        >
                           {{ t.time }}
                         </div>
                       </div>
-
-                      <div class="text-sm font-semibold" :class="selectedTime === t.time ? 'text-white/90' : 'text-[#7A7A7A]'">
+                      <div
+                        class="text-sm font-semibold"
+                        :class="selectedTime === t.time ? 'text-white/90' : 'text-[#7A7A7A]'"
+                      >
                         剩餘 {{ t.remain }}
                       </div>
                     </button>
@@ -227,18 +190,12 @@
               </div>
             </div>
           </div>
-
-          <!-- Step 4 -->
           <div v-else-if="step === 4">
             <h2 class="text-3xl font-bold tracking-tight">聯絡資訊</h2>
-
             <div class="mt-10 rounded-2xl border border-[#E6E6DF] bg-white px-10 py-6">
               <div class="grid grid-cols-[44px_1fr] gap-6 py-7">
                 <div class="pt-1 text-[#6E6E6A]">
-                  <svg width="26" height="26" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-                    <path d="M20 21a8 8 0 1 0-16 0" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
-                    <path d="M12 13a4 4 0 1 0 0-8 4 4 0 0 0 0 8z" stroke="currentColor" stroke-width="2" />
-                  </svg>
+                  <i class="fa-regular fa-user text-2xl" aria-hidden="true"></i>
                 </div>
                 <div>
                   <div class="text-base font-semibold text-[#6E6E6A]">姓名</div>
@@ -249,20 +206,10 @@
                   />
                 </div>
               </div>
-
               <div class="h-px bg-[#E6E6DF]" />
-
               <div class="grid grid-cols-[44px_1fr] gap-6 py-7">
                 <div class="pt-1 text-[#6E6E6A]">
-                  <svg width="26" height="26" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-                    <path
-                      d="M22 16.92v3a2 2 0 0 1-2.18 2A19.8 19.8 0 0 1 3 5.18 2 2 0 0 1 5.11 3h3a2 2 0 0 1 2 1.72c.12.86.32 1.7.59 2.5a2 2 0 0 1-.45 2.11L9.1 10.9a16 16 0 0 0 4 4l1.57-1.15a2 2 0 0 1 2.11-.45c.8.27 1.64.47 2.5.59A2 2 0 0 1 22 16.92z"
-                      stroke="currentColor"
-                      stroke-width="2"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                    />
-                  </svg>
+                  <i class="fa-solid fa-phone text-2xl" aria-hidden="true"></i>
                 </div>
                 <div>
                   <div class="text-base font-semibold text-[#6E6E6A]">電話</div>
@@ -274,26 +221,10 @@
                   />
                 </div>
               </div>
-
               <div class="h-px bg-[#E6E6DF]" />
-
               <div class="grid grid-cols-[44px_1fr] gap-6 py-7">
                 <div class="pt-1 text-[#6E6E6A]">
-                  <svg width="26" height="26" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-                    <path
-                      d="M4 4h16a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2z"
-                      stroke="currentColor"
-                      stroke-width="2"
-                      stroke-linecap="round"
-                    />
-                    <path
-                      d="m22 7-10 7L2 7"
-                      stroke="currentColor"
-                      stroke-width="2"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                    />
-                  </svg>
+                  <i class="fa-regular fa-envelope text-2xl" aria-hidden="true"></i>
                 </div>
                 <div>
                   <div class="text-base font-semibold text-[#6E6E6A]">電子郵件</div>
@@ -307,23 +238,12 @@
               </div>
             </div>
           </div>
-
-          <!-- Step 5 -->
           <div v-else>
             <h2 class="text-3xl font-bold tracking-tight">確認預約資訊</h2>
-
             <div class="mt-10 rounded-2xl border border-[#E6E6DF] bg-white px-10 py-2">
               <div class="grid grid-cols-[44px_1fr] gap-6 py-8">
                 <div class="pt-1 text-[#6E6E6A]">
-                  <svg width="26" height="26" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-                    <path
-                      d="M14.7 6.3a4 4 0 0 0-5.4 5.4L3 18l3 3 6.3-6.3a4 4 0 0 0 5.4-5.4l-2.2 2.2-2-2 2.2-2.2z"
-                      stroke="currentColor"
-                      stroke-width="2"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                    />
-                  </svg>
+                  <i class="fa-solid fa-wrench text-2xl" aria-hidden="true"></i>
                 </div>
                 <div>
                   <div class="text-base font-semibold text-[#6E6E6A]">服務項目</div>
@@ -331,47 +251,20 @@
                   <div class="mt-2 text-sm text-[#7A7A7A]">預估時間：{{ selectedServiceObj?.minutes ?? "—" }}分鐘</div>
                 </div>
               </div>
-
               <div class="h-px bg-[#E6E6DF]" />
-
               <div class="grid grid-cols-[44px_1fr] gap-6 py-8">
                 <div class="pt-1 text-[#6E6E6A]">
-                  <svg width="26" height="26" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-                    <path
-                      d="M3 13l1.5-5A2 2 0 0 1 6.4 6h11.2a2 2 0 0 1 1.9 2L21 13"
-                      stroke="currentColor"
-                      stroke-width="2"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                    />
-                    <path
-                      d="M5 13h14v6a1 1 0 0 1-1 1h-1a1 1 0 0 1-1-1v-1H8v1a1 1 0 0 1-1 1H6a1 1 0 0 1-1-1v-6z"
-                      stroke="currentColor"
-                      stroke-width="2"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                    />
-                    <path d="M7.5 16.5h.01M16.5 16.5h.01" stroke="currentColor" stroke-width="3" stroke-linecap="round" />
-                  </svg>
+                  <i class="fa-solid fa-car text-2xl" aria-hidden="true"></i>
                 </div>
                 <div>
                   <div class="text-base font-semibold text-[#6E6E6A]">車輛類型</div>
                   <div class="mt-2 text-lg font-semibold">{{ selectedVehicleObj?.title || "—" }}</div>
                 </div>
               </div>
-
               <div class="h-px bg-[#E6E6DF]" />
-
               <div class="grid grid-cols-[44px_1fr] gap-6 py-8">
                 <div class="pt-1 text-[#6E6E6A]">
-                  <svg width="26" height="26" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-                    <path
-                      d="M8 2v3M16 2v3M3.5 9h17M6 5h12a2 2 0 0 1 2 2v13a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V7a2 2 0 0 1 2-2z"
-                      stroke="currentColor"
-                      stroke-width="2"
-                      stroke-linecap="round"
-                    />
-                  </svg>
+                  <i class="fa-regular fa-calendar text-2xl" aria-hidden="true"></i>
                 </div>
                 <div>
                   <div class="text-base font-semibold text-[#6E6E6A]">預約日期 &amp; 時段</div>
@@ -379,61 +272,30 @@
                   <div class="mt-2 text-lg font-semibold text-[#7A7A7A]">{{ selectedTimeLong || "—" }}</div>
                 </div>
               </div>
-
               <div class="h-px bg-[#E6E6DF]" />
-
               <div class="grid grid-cols-[44px_1fr] gap-6 py-8">
                 <div class="pt-1 text-[#6E6E6A]">
-                  <svg width="26" height="26" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-                    <path d="M20 21a8 8 0 1 0-16 0" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
-                    <path d="M12 13a4 4 0 1 0 0-8 4 4 0 0 0 0 8z" stroke="currentColor" stroke-width="2" />
-                  </svg>
+                  <i class="fa-regular fa-user text-2xl" aria-hidden="true"></i>
                 </div>
                 <div>
                   <div class="text-base font-semibold text-[#6E6E6A]">姓名</div>
                   <div class="mt-2 text-lg font-semibold">{{ contactName || "—" }}</div>
                 </div>
               </div>
-
               <div class="h-px bg-[#E6E6DF]" />
-
               <div class="grid grid-cols-[44px_1fr] gap-6 py-8">
                 <div class="pt-1 text-[#6E6E6A]">
-                  <svg width="26" height="26" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-                    <path
-                      d="M22 16.92v3a2 2 0 0 1-2.18 2A19.8 19.8 0 0 1 3 5.18 2 2 0 0 1 5.11 3h3a2 2 0 0 1 2 1.72c.12.86.32 1.7.59 2.5a2 2 0 0 1-.45 2.11L9.1 10.9a16 16 0 0 0 4 4l1.57-1.15a2 2 0 0 1 2.11-.45c.8.27 1.64.47 2.5.59A2 2 0 0 1 22 16.92z"
-                      stroke="currentColor"
-                      stroke-width="2"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                    />
-                  </svg>
+                  <i class="fa-solid fa-phone text-2xl" aria-hidden="true"></i>
                 </div>
                 <div>
                   <div class="text-base font-semibold text-[#6E6E6A]">電話</div>
                   <div class="mt-2 text-lg font-semibold">{{ contactPhone || "—" }}</div>
                 </div>
               </div>
-
               <div class="h-px bg-[#E6E6DF]" />
-
               <div class="grid grid-cols-[44px_1fr] gap-6 py-8">
                 <div class="pt-1 text-[#6E6E6A]">
-                  <svg width="26" height="26" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-                    <path
-                      d="M4 4h16a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2z"
-                      stroke="currentColor"
-                      stroke-width="2"
-                      stroke-linecap="round"
-                    />
-                    <path
-                      d="m22 7-10 7L2 7"
-                      stroke="currentColor"
-                      stroke-width="2"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                    />
-                  </svg>
+                  <i class="fa-regular fa-envelope text-2xl" aria-hidden="true"></i>
                 </div>
                 <div>
                   <div class="text-base font-semibold text-[#6E6E6A]">電子郵件</div>
@@ -443,8 +305,6 @@
             </div>
           </div>
         </div>
-
-        <!-- Bottom actions -->
         <div class="mt-14 flex items-center justify-between">
           <button
             type="button"
@@ -455,7 +315,6 @@
           >
             上一步
           </button>
-
           <button
             v-if="step < 5"
             type="button"
@@ -466,7 +325,6 @@
           >
             下一步
           </button>
-
           <button
             v-else
             type="button"
@@ -479,58 +337,34 @@
         </div>
       </div>
     </div>
-
-    <!-- Success overlay (改成你提供的樣式) -->
     <div v-if="showSuccess" class="fixed inset-0 z-50 bg-black/40">
       <div class="absolute inset-0 flex items-center justify-center p-6">
         <div
           class="relative w-full max-w-[680px] rounded-2xl border border-[#E6E6DF] bg-[#FBFAF7] shadow-[0_20px_60px_rgba(0,0,0,0.25)]"
         >
-          <!-- close -->
           <button
             type="button"
             class="absolute right-5 top-5 text-[#6E6E6A] hover:opacity-80"
             aria-label="close"
             @click="showSuccess = false"
           >
-            ✕
+            <i class="fa-solid fa-xmark text-xl" aria-hidden="true"></i>
           </button>
-
           <div class="px-10 pb-10 pt-12 text-center">
-            <!-- icon circle -->
-            <div class="mx-auto grid h-20 w-20 place-items-center rounded-full bg-[#F2F1EC]">
-              <svg width="44" height="44" viewBox="0 0 24 24" fill="none" aria-hidden="true" class="text-[#6E6E6A]">
-                <path
-                  d="M22 11.08V12a10 10 0 1 1-5.93-9.14"
-                  stroke="currentColor"
-                  stroke-width="2.2"
-                  stroke-linecap="round"
-                />
-                <path
-                  d="M22 4 12 14.01l-3-3"
-                  stroke="currentColor"
-                  stroke-width="2.2"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                />
-              </svg>
+            <div class="mx-auto grid h-20 w-20 place-items-center rounded-full bg-[#F2F1EC] text-[#6E6E6A]">
+              <i class="fa-regular fa-circle-check text-4xl" aria-hidden="true"></i>
             </div>
-
             <div class="mt-6 text-3xl font-extrabold">預約成功！</div>
             <div class="mt-3 text-lg font-semibold text-[#7A7A7A]">您的預約已送出</div>
-
-            <!-- booking code card -->
             <div class="mx-auto mt-8 w-full max-w-[260px] rounded-2xl border border-[#E6E6DF] bg-[#F6F5F0] px-6 py-5">
               <div class="text-sm font-semibold text-[#7A7A7A]">預約編號</div>
               <div class="mt-2 text-lg font-extrabold tracking-wide text-[#2B2B2B]">
                 {{ bookingCode }}
               </div>
             </div>
-
             <div class="mt-8 text-sm leading-7 text-[#7A7A7A]">
               我們已發送確認信至您的電子郵件，請留意相關通知。
             </div>
-
             <button
               type="button"
               class="mt-8 w-full rounded-xl bg-[#6E6E6A] px-6 py-4 text-base font-bold text-white hover:opacity-95 active:opacity-90"
@@ -560,17 +394,15 @@ const steps: Array<{ key: StepKey; label: string }> = [
 
 const step = ref<number>(1);
 
-/** Step 1 */
 type ServiceKey = "oil" | "tire" | "brake" | "maintain";
-const serviceOptions: Array<{ key: ServiceKey; title: string; minutes: number; icon: string }> = [
-  { key: "oil", title: "機油更換", minutes: 30, icon: "🛠️" },
-  { key: "tire", title: "輪胎檢修", minutes: 45, icon: "🚗" },
-  { key: "brake", title: "煞車系統檢查", minutes: 60, icon: "✅" },
-  { key: "maintain", title: "定期保養", minutes: 90, icon: "🔧" },
+const serviceOptions: Array<{ key: ServiceKey; title: string; minutes: number; fa: string }> = [
+  { key: "oil", title: "機油更換", minutes: 30, fa: "fa-solid fa-oil-can" },
+  { key: "tire", title: "輪胎檢修", minutes: 45, fa: "fa-solid fa-car-side" },
+  { key: "brake", title: "煞車系統檢查", minutes: 60, fa: "fa-solid fa-circle-check" },
+  { key: "maintain", title: "定期保養", minutes: 90, fa: "fa-solid fa-screwdriver-wrench" },
 ];
 const selectedService = ref<ServiceKey | null>(null);
 
-/** Step 2 */
 type VehicleKey = "sedan" | "suv" | "truck" | "motor";
 const vehicleOptions: Array<{ key: VehicleKey; title: string; subtitle: string }> = [
   { key: "sedan", title: "轎車", subtitle: "一般房車" },
@@ -580,7 +412,6 @@ const vehicleOptions: Array<{ key: VehicleKey; title: string; subtitle: string }
 ];
 const selectedVehicle = ref<VehicleKey | null>(null);
 
-/** Step 3 */
 const weekDaysMon = ["一", "二", "三", "四", "五", "六", "日"];
 const monthOptions = ["一月", "二月", "三月", "四月", "五月", "六月", "七月", "八月", "九月", "十月", "十一月", "十二月"];
 
@@ -599,7 +430,6 @@ const timeOptions = [
   { time: "15:00", remain: 6 },
 ];
 
-/** Step 4 contact */
 const contactName = ref<string>("");
 const contactPhone = ref<string>("");
 const contactEmail = ref<string>("");
@@ -608,7 +438,6 @@ const isContactValid = computed(() => {
   return !!contactName.value.trim() && !!contactPhone.value.trim() && !!contactEmail.value.trim();
 });
 
-/** Unlock logic */
 const maxUnlocked = computed(() => {
   if (step.value === 1) return selectedService.value ? 2 : 1;
   if (step.value === 2) return selectedVehicle.value ? 3 : 2;
@@ -649,14 +478,12 @@ const canFinish = computed(() => {
   );
 });
 
-/** Progress overlay */
 const progressWidth = computed(() => {
   const segments = steps.length - 1;
   const done = Math.max(0, step.value - 1);
   return `${(done / segments) * 100}%`;
 });
 
-/** Stepper UI */
 const circleClass = (n: number) => {
   if (n <= step.value) return "bg-[#6E6E6A] text-white";
   return "bg-white text-[#7A7A7A] border border-[#E6E6DF]";
@@ -666,7 +493,6 @@ const labelClass = (n: number) => {
   return "text-[#7A7A7A]";
 };
 
-/** Cards */
 const serviceCardClass = (key: ServiceKey) => {
   return selectedService.value === key ? "border-[#6E6E6A]" : "border-[#E6E6DF] hover:border-[#CFCFC6]";
 };
@@ -676,7 +502,6 @@ const vehicleCardClass = (key: VehicleKey) => {
     : "border-[#E6E6DF] bg-white hover:border-[#CFCFC6]";
 };
 
-/** Buttons */
 const prevBtnClass = computed(() => {
   return step.value === 1
     ? "border-[#E6E6DF] text-[#B5B5AD] bg-[#FBFAF7] cursor-not-allowed"
@@ -688,7 +513,6 @@ const nextBtnClass = computed(() => {
     : "bg-[#D1D1CB] cursor-not-allowed";
 });
 
-/** Calendar helpers */
 const toMonIndex = (jsDay: number) => (jsDay + 6) % 7;
 
 const calendarCellsMon42 = computed(() => {
@@ -740,7 +564,6 @@ const nextMonth = () => {
   }
 };
 
-/** Long date/time */
 const weekdayCN = ["星期日", "星期一", "星期二", "星期三", "星期四", "星期五", "星期六"];
 const pad2 = (n: number) => String(n).padStart(2, "0");
 
@@ -765,16 +588,13 @@ const timeRowClass = (t: string) => {
   return active ? "border-transparent bg-[#6E6E6A]" : "border-[#E6E6DF] bg-white hover:border-[#CFCFC6]";
 };
 
-/** Step 5 display helpers */
 const selectedServiceObj = computed(() => serviceOptions.find((s) => s.key === selectedService.value) || null);
 const selectedVehicleObj = computed(() => vehicleOptions.find((v) => v.key === selectedVehicle.value) || null);
 
-/** Success dialog */
 const showSuccess = ref(false);
 const bookingCode = ref<string>("");
 
 const randomBookingCode = () => {
-  // BK + 8 digits
   const n = Math.floor(10000000 + Math.random() * 90000000);
   return `BK${n}`;
 };
@@ -788,7 +608,6 @@ const finish = () => {
 const resetAll = () => {
   showSuccess.value = false;
 
-  // reset flow
   step.value = 1;
   selectedService.value = null;
   selectedVehicle.value = null;
@@ -798,7 +617,5 @@ const resetAll = () => {
   contactName.value = "";
   contactPhone.value = "";
   contactEmail.value = "";
-
-  // keep view year/month as is (也可以改回預設)
 };
 </script>

--- a/src/components/ServiceSearch.vue
+++ b/src/components/ServiceSearch.vue
@@ -1,90 +1,143 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+
+const currentStep = ref<number>(1);
+const selectedServiceId = ref<string>("");
+const steps = [
+	{ step: 1, label: `選擇服務` },
+	{ step: 2, label: `車輛類型` },
+	{ step: 3, label: `選擇日期` },
+	{ step: 4, label: `選擇時段` },
+	{ step: 5, label: `確認預約` },
+];
+
+const serviceOptions = [
+	{ id: `oil-change`, title: `機油更換`, duration: `30分鐘`, icon: `fa-wrench` },
+	{ id: `tire-check`, title: `輪胎檢修`, duration: `45分鐘`, icon: `fa-car` },
+	{ id: `brake-check`, title: `煞車系統檢查`, duration: `60分鐘`, icon: `fa-shield-halved` },
+	{ id: `maintenance`, title: `定期保養`, duration: `90分鐘`, icon: `fa-screwdriver-wrench` },
+];
+</script>
+
 <template>
-	<div class="min-h-screen bg-[#faf9f7]">
-		<nav class="border-b border-[#ede9e4] bg-white">
-			<div class="mx-auto flex h-16 max-w-[1200px] items-center justify-between px-4">
-				<div class="flex items-center gap-3">
-					<div class="flex h-10 w-10 items-center justify-center rounded-lg bg-[#8b7e6b] text-white">
-						<i class="fa-solid fa-calendar"></i>
-					</div>
-					<div>
-						<p class="text-base font-semibold text-[#3f3a34]">職人維修工房</p>
-						<p class="text-sm text-[#8b8378]">專業維修・值得信賴</p>
-					</div>
+	<div class="flex flex-col min-h-screen bg-[#f9f9f9] text-[#4a4a4a] font-sans">
+		<header class="flex justify-between items-center px-8 py-4 bg-white border-b border-gray-100">
+			<div class="flex items-center gap-4">
+				<div class="flex items-center justify-center w-10 h-10 text-white rounded bg-[#6b635c]">
+					<i class="text-xl fa-regular fa-calendar"></i>
 				</div>
-				<div class="hidden items-center gap-3 md:flex">
-					<button type="button" class="rounded-lg bg-[#8b7e6b] px-4 py-2 text-sm text-white">預約服務</button>
-					<button type="button" class="rounded-lg border border-[#d6d0c8] px-4 py-2 text-sm text-[#3f3a34]">我的預約</button>
-					<button type="button" class="rounded-lg bg-[#6f665a] px-4 py-2 text-sm text-white">✓ 開發模式</button>
+				<div>
+					<h1 class="text-lg font-bold tracking-wide text-gray-800">職人維修工房</h1>
+					<p class="text-xs text-gray-500">專業維修・值得信賴</p>
 				</div>
 			</div>
-		</nav>
-		<main class="mx-auto max-w-[1200px] px-4 py-8">
-			<section class="mb-8 hidden md:block">
-				<div class="flex items-center justify-between">
-					<div v-for="step in 5" :key="step" class="flex flex-1 items-center">
-						<div class="flex flex-col items-center">
-							<div :class="[
-									'flex h-8 w-8 items-center justify-center rounded-full text-sm',
-									step === 1
-										? 'bg-[#8b7e6b] text-white'
-										: 'border border-[#d6d0c8] text-[#8b8378]'
-								]">
-								{{ step }}
-							</div>
-							<p class="mt-2 text-sm text-[#6f665a]">
-								{{ ['選擇服務','車輛類型','選擇日期','選擇時段','確認預約'][step - 1] }}
-							</p>
+			<div class="flex items-center gap-4">
+				<button class="px-4 py-2 text-sm font-medium text-white transition-colors rounded bg-[#6b635c] hover:bg-[#5a534d]">預約服務
+				</button>
+				<button class="text-sm font-medium text-gray-600 transition-colors hover:text-gray-900">我的預約
+				</button>
+				<button class="flex items-center gap-2 px-4 py-2 text-sm text-white rounded bg-[#6b635c]">
+					<i class="fa-solid fa-check"></i>
+					開發模式
+				</button>
+			</div>
+		</header>
+		<main class="flex-1 w-full max-w-6xl p-8 mx-auto">
+			<div class="flex flex-col p-10 bg-white shadow-lg rounded-2xl min-h-[600px]">
+				<div class="relative flex justify-between w-full px-12 mb-12">
+					<div class="absolute top-5 left-0 right-0 w-full h-[2px] bg-gray-200 -z-10 translate-y-[-50%] mx-auto max-w-[90%]"></div>
+					<div 
+						v-for="s in steps" 
+						:key="s.step"
+						class="flex flex-col items-center gap-3 bg-white"
+					>
+						<div 
+							class="flex items-center justify-center w-10 h-10 text-sm font-bold transition-all border-2 rounded-full"
+							:class="[
+								currentStep === s.step 
+									? `bg-[#6b635c] border-[#6b635c] text-white` 
+									: `bg-white border-gray-300 text-gray-400`
+							]"
+						>
+							{{ s.step }}
 						</div>
-						<div v-if="step !== 5" class="mx-2 h-px flex-1 bg-[#ede9e4]"></div>
+						<span 
+							class="text-sm tracking-wide"
+							:class="currentStep === s.step ? `text-[#6b635c] font-medium` : `text-gray-400`"
+						>
+							{{ s.label }}
+						</span>
 					</div>
 				</div>
-			</section>
-			<!-- Dev Mode -->
-			<section class="mb-10 rounded-xl border border-[#ede9e4] bg-white p-6">
-				<p class="mb-4 text-sm text-[#6f665a]">開發者模式・快速切換步驟：</p>
-				<div class="mb-6 flex flex-wrap gap-2">
-					<button
-						v-for="item in ['選擇服務','車輛類型','選擇日期','選擇時段','確認預約']"
-						:key="item"
-						type="button"
-						class="rounded-lg border border-[#d6d0c8] px-4 py-2 text-sm text-[#3f3a34]"
-					>
-						{{ item }}
+				<div class="p-6 mb-10 border border-gray-100 rounded-lg bg-gray-50">
+					<p class="mb-3 text-sm font-medium text-gray-500">開發者模式 - 快速切換步驟：</p>
+					<div class="flex gap-3 mb-4">
+						<button 
+							v-for="s in steps"
+							:key="`dev-btn-${s.step}`"
+							@click="currentStep = s.step"
+							class="px-4 py-2 text-sm font-bold text-gray-700 transition-colors bg-white border border-gray-300 rounded shadow-sm hover:bg-gray-100"
+							:class="{ '!bg-[#6b635c] !text-white !border-[#6b635c]': currentStep === s.step }"
+						>
+							{{ s.step }}. {{ s.label }}
+						</button>
+					</div>
+					<p class="mb-3 text-sm font-medium text-gray-500">快速填充測試資料：</p>
+					<button 
+						@click="selectedServiceId = `oil-change`"
+						class="px-4 py-2 text-sm font-bold text-gray-600 transition-colors bg-gray-200 rounded hover:bg-gray-300">
+						填充所有欄位
 					</button>
 				</div>
-				<button type="button" class="rounded-lg bg-[#d6d0c8] px-4 py-2 text-sm text-[#3f3a34]">填充所有欄位</button>
-			</section>
-			<section>
-				<h2 class="mb-6 text-xl font-semibold text-[#3f3a34]">選擇服務項目</h2>
-				<div class="grid gap-6 md:grid-cols-2">
-					<div
-						v-for="service in [
-							{ icon: 'wrench', title: '機油更換', time: '30分鐘' },
-							{ icon: 'car', title: '輪胎檢修', time: '45分鐘' },
-							{ icon: 'circle-check', title: '煞車系統檢查', time: '60分鐘' },
-							{ icon: 'wrench', title: '定期保養', time: '90分鐘' }
-						]"
-						:key="service.title"
-						class="flex items-center gap-4 rounded-xl border border-[#ede9e4] bg-white p-6"
-					>
-						<div class="flex h-12 w-12 items-center justify-center rounded-lg bg-[#f3f1ee] text-[#6f665a]">
-							<i :class="`fa-solid fa-${service.icon}`"></i>
-						</div>
-						<div>
-							<p class="text-base font-semibold text-[#3f3a34]">
-								{{ service.title }}
-							</p>
-							<p class="text-sm text-[#8b8378]">
-								預估時間：{{ service.time }}
-							</p>
+				<div v-if="currentStep === 1" class="flex-1">
+					<h2 class="mb-6 text-xl font-bold text-gray-800">選擇服務項目</h2>
+					<div class="grid grid-cols-2 gap-6">
+						<div 
+							v-for="service in serviceOptions"
+							:key="service.id"
+							@click="selectedServiceId = service.id"
+							class="flex items-center gap-6 p-6 transition-all border rounded-xl cursor-pointer group hover:shadow-md"
+							:class="[
+								selectedServiceId === service.id 
+									? `border-[#6b635c] bg-stone-50` 
+									: `border-gray-200 bg-white`
+							]"
+						>
+							<div 
+								class="flex items-center justify-center w-16 h-16 transition-colors rounded-lg"
+								:class="[
+									selectedServiceId === service.id 
+										? `bg-[#6b635c] text-white` 
+										: `bg-[#6b635c] text-white opacity-80`
+								]"
+							>
+								<i class="text-2xl fa-solid" :class="service.icon"></i>
+							</div>
+							<div>
+								<h3 class="text-lg font-bold text-gray-800">{{ service.title }}</h3>
+								<p class="text-sm text-gray-500">預估時間：{{ service.duration }}</p>
+							</div>
 						</div>
 					</div>
 				</div>
-				<div class="mt-10 flex items-center justify-between">
-					<button type="button" class="rounded-lg border border-[#d6d0c8] px-6 py-2 text-sm text-[#8b8378]">上一步</button>
-					<button type="button" class="rounded-lg bg-[#b7afa5] px-6 py-2 text-sm text-white">下一步</button>
+				<div v-else class="flex flex-col items-center justify-center flex-1 h-64 text-gray-400 border-2 border-dashed rounded-xl">
+					<i class="mb-4 text-4xl fa-solid fa-person-digging"></i>
+					<p>步驟 {{ currentStep }} 內容建置中...</p>
 				</div>
-			</section>
+				<div class="flex justify-between mt-12 pt-6 border-t border-gray-100">
+					<button 
+						@click="currentStep > 1 ? currentStep-- : null"
+						:disabled="currentStep === 1"
+						class="px-8 py-3 text-sm font-medium transition-colors border border-gray-200 rounded disabled:opacity-50 disabled:cursor-not-allowed hover:bg-gray-50 text-gray-500">
+						上一步
+					</button>
+					<button 
+						@click="currentStep < 5 ? currentStep++ : null"
+						class="px-8 py-3 text-sm font-medium text-white transition-colors rounded shadow-md bg-[#6b635c] hover:bg-[#5a534d]">
+						下一步
+					</button>
+				</div>
+			</div>
 		</main>
 	</div>
 </template>

--- a/src/components/ServiceSearch.vue
+++ b/src/components/ServiceSearch.vue
@@ -1,124 +1,804 @@
-<script setup lang="ts">
-import { ref } from 'vue';
-
-const currentStep = ref<number>(1);
-const selectedServiceId = ref<string>("");
-
-const steps = [
-  { step: 1, label: '選擇服務' },
-  { step: 2, label: '車輛類型' },
-  { step: 3, label: '選擇日期' },
-  { step: 4, label: '選擇時段' },
-  { step: 5, label: '確認預約' },
-];
-
-const serviceOptions = [
-  { id: 'oil-change', title: '機油更換', duration: '30分鐘', icon: 'fa-wrench' },
-  { id: 'tire-check', title: '輪胎檢修', duration: '45分鐘', icon: 'fa-car' },
-  { id: 'brake-check', title: '煞車系統檢查', duration: '60分鐘', icon: 'fa-shield-halved' },
-  { id: 'maintenance', title: '定期保養', duration: '90分鐘', icon: 'fa-screwdriver-wrench' },
-];
-</script>
-
 <template>
-  <div class="flex flex-col min-h-screen bg-[#f9f9f9] text-[#4a4a4a] font-sans">
-    <main class="flex-1 w-full max-w-6xl p-8 mx-auto">
-      <div class="flex flex-col p-10 bg-white shadow-lg rounded-2xl min-h-[600px]">
-
-        <!-- Step Indicator -->
-        <div class="relative flex justify-between w-full px-12 mb-12">
+  <div class="min-h-screen bg-[#FAF8F5] px-6 py-10 text-[#2B2B2B]">
+    <div class="mx-auto w-full max-w-6xl rounded-[28px] border border-[#E6E6DF] bg-white shadow-[0_2px_10px_rgba(0,0,0,0.06)]">
+      <div class="p-10">
+        <div class="relative">
+          <div class="absolute left-0 right-0 top-[18px] h-px bg-[#E6E6DF]" />
           <div
-            class="absolute top-5 left-0 right-0 w-full h-[2px] bg-gray-200 -z-10 translate-y-[-50%] mx-auto max-w-[90%]"
+            v-if="step > 1"
+            class="absolute left-0 top-[18px] h-px bg-[#6E6E6A]"
+            :style="{ width: progressWidth }"
           />
-          <div
-            v-for="s in steps"
-            :key="s.step"
-            class="flex flex-col items-center gap-3 bg-white"
-          >
-            <div
-              class="flex items-center justify-center w-10 h-10 text-sm font-bold transition-all border-2 rounded-full"
-              :class="currentStep === s.step
-                ? 'bg-[#6b635c] border-[#6b635c] text-white'
-                : 'bg-white border-gray-300 text-gray-400'"
+          <div class="grid grid-cols-5 items-start gap-0">
+            <button
+              v-for="(s, idx) in steps"
+              :key="s.key"
+              type="button"
+              class="group relative flex flex-col items-center gap-3"
+              @click="goToStep(idx + 1)"
             >
-              {{ s.step }}
-            </div>
-            <span
-              class="text-sm tracking-wide"
-              :class="currentStep === s.step
-                ? 'text-[#6b635c] font-medium'
-                : 'text-gray-400'"
-            >
-              {{ s.label }}
-            </span>
-          </div>
-        </div>
-
-        <!-- Step 1 -->
-        <div v-if="currentStep === 1" class="flex-1">
-          <h2 class="mb-6 text-xl font-bold text-gray-800">
-            選擇服務項目
-          </h2>
-
-          <div class="grid grid-cols-2 gap-6">
-            <div
-              v-for="service in serviceOptions"
-              :key="service.id"
-              @click="selectedServiceId = service.id"
-              class="flex items-center gap-6 p-6 transition-all border rounded-xl cursor-pointer hover:shadow-md"
-              :class="selectedServiceId === service.id
-                ? 'border-[#6b635c] bg-stone-50'
-                : 'border-gray-200 bg-white'"
-            >
-              <div
-                class="flex items-center justify-center w-16 h-16 rounded-lg"
-                :class="selectedServiceId === service.id
-                  ? 'bg-[#6b635c] text-white'
-                  : 'bg-[#6b635c] text-white opacity-80'"
+              <span
+                class="grid h-9 w-9 place-items-center rounded-full text-sm font-semibold transition"
+                :class="circleClass(idx + 1)"
               >
-                <i class="text-2xl fa-solid" :class="service.icon"></i>
+                <template v-if="idx + 1 < step">
+                  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                    <path
+                      d="M20 6L9 17l-5-5"
+                      stroke="white"
+                      stroke-width="2.5"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    />
+                  </svg>
+                </template>
+                <template v-else>
+                  {{ idx + 1 }}
+                </template>
+              </span>
+              <span class="text-sm transition" :class="labelClass(idx + 1)">
+                {{ s.label }}
+              </span>
+            </button>
+          </div>
+        </div>
+        <div class="mt-16">
+          <!-- Step 1 -->
+          <div v-if="step === 1">
+            <h2 class="text-3xl font-bold tracking-tight">選擇服務項目</h2>
+
+            <div class="mt-10 grid grid-cols-2 gap-6">
+              <button
+                v-for="item in serviceOptions"
+                :key="item.key"
+                type="button"
+                class="flex items-center gap-5 rounded-2xl border bg-white px-7 py-6 text-left transition"
+                :class="serviceCardClass(item.key)"
+                @click="selectedService = item.key"
+              >
+                <div class="grid h-14 w-14 place-items-center rounded-2xl bg-[#F5F4EF]">
+                  <span class="text-xl">{{ item.icon }}</span>
+                </div>
+
+                <div class="min-w-0">
+                  <div class="text-lg font-semibold">{{ item.title }}</div>
+                  <div class="mt-1 text-sm text-[#7A7A7A]">預估時間：{{ item.minutes }}分鐘</div>
+                </div>
+              </button>
+            </div>
+          </div>
+
+          <!-- Step 2 -->
+          <div v-else-if="step === 2">
+            <h2 class="text-3xl font-bold tracking-tight">選擇車輛類型</h2>
+
+            <div class="mt-10 grid grid-cols-2 gap-6">
+              <button
+                v-for="v in vehicleOptions"
+                :key="v.key"
+                type="button"
+                class="flex items-center gap-6 rounded-2xl border px-8 py-7 text-left transition"
+                :class="vehicleCardClass(v.key)"
+                @click="selectedVehicle = v.key"
+              >
+                <span
+                  class="relative grid h-5 w-5 place-items-center rounded-full border"
+                  :class="selectedVehicle === v.key ? 'border-[#6E6E6A]' : 'border-[#E6E6DF]'"
+                >
+                  <span v-if="selectedVehicle === v.key" class="h-2.5 w-2.5 rounded-full bg-[#6E6E6A]" />
+                </span>
+
+                <div>
+                  <div class="text-lg font-semibold">{{ v.title }}</div>
+                  <div class="mt-1 text-sm text-[#7A7A7A]">{{ v.subtitle }}</div>
+                </div>
+              </button>
+            </div>
+          </div>
+
+          <!-- Step 3 -->
+          <div v-else-if="step === 3">
+            <h2 class="text-3xl font-bold tracking-tight">選擇日期</h2>
+
+            <div class="mt-10 grid grid-cols-2 gap-8">
+              <!-- Left: Calendar card -->
+              <div class="rounded-2xl border border-[#E6E6DF] bg-white p-8">
+                <div class="flex items-center justify-center gap-4">
+                  <button
+                    type="button"
+                    class="grid h-10 w-10 place-items-center rounded-xl bg-[#F5F4EF] text-lg text-[#6E6E6A] hover:opacity-90"
+                    @click="prevMonth"
+                    aria-label="prev month"
+                  >
+                    ‹
+                  </button>
+
+                  <div class="flex items-center gap-3">
+                    <div class="relative">
+                      <select
+                        v-model.number="viewYear"
+                        class="h-10 appearance-none rounded-xl bg-[#F5F4EF] px-4 pr-10 text-sm font-semibold text-[#2B2B2B] outline-none"
+                      >
+                        <option v-for="y in yearOptions" :key="y" :value="y">{{ y }}年</option>
+                      </select>
+                      <span class="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-[#7A7A7A]">▾</span>
+                    </div>
+
+                    <div class="relative">
+                      <select
+                        v-model.number="viewMonth"
+                        class="h-10 appearance-none rounded-xl bg-[#F5F4EF] px-4 pr-10 text-sm font-semibold text-[#2B2B2B] outline-none"
+                      >
+                        <option v-for="(m, idx) in monthOptions" :key="m" :value="idx">{{ m }}</option>
+                      </select>
+                      <span class="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-[#7A7A7A]">▾</span>
+                    </div>
+                  </div>
+
+                  <button
+                    type="button"
+                    class="grid h-10 w-10 place-items-center rounded-xl bg-[#F5F4EF] text-lg text-[#6E6E6A] hover:opacity-90"
+                    @click="nextMonth"
+                    aria-label="next month"
+                  >
+                    ›
+                  </button>
+                </div>
+
+                <div class="mt-10 grid grid-cols-7 gap-4 text-center text-sm font-semibold text-[#6E6E6A]">
+                  <div v-for="d in weekDaysMon" :key="d">{{ d }}</div>
+                </div>
+
+                <div class="mt-6 grid grid-cols-7 gap-4 text-center">
+                  <button
+                    v-for="cell in calendarCellsMon42"
+                    :key="cell.key"
+                    type="button"
+                    class="h-11 w-11 rounded-xl text-base font-semibold transition"
+                    :class="dayBtnClass(cell.date, cell.inMonth)"
+                    @click="onPickDate(cell.date)"
+                  >
+                    {{ cell.date.getDate() }}
+                  </button>
+                </div>
               </div>
 
-              <div>
-                <h3 class="text-lg font-bold text-gray-800">
-                  {{ service.title }}
-                </h3>
-                <p class="text-sm text-gray-500">
-                  預估時間：{{ service.duration }}
-                </p>
+              <!-- Right: Summary + Times -->
+              <div class="space-y-6">
+                <div class="rounded-2xl border border-[#E6E6DF] bg-white px-6 py-5">
+                  <div class="flex items-start gap-4">
+                    <div class="mt-0.5 text-[#6E6E6A]">
+                      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                        <path
+                          d="M8 2v3M16 2v3M3.5 9h17M6 5h12a2 2 0 0 1 2 2v13a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V7a2 2 0 0 1 2-2z"
+                          stroke="currentColor"
+                          stroke-width="2"
+                          stroke-linecap="round"
+                        />
+                      </svg>
+                    </div>
+
+                    <div class="min-w-0">
+                      <div class="text-lg font-bold">{{ selectedDateLong || "尚未選擇日期" }}</div>
+                      <div class="mt-2 text-lg font-semibold text-[#7A7A7A]">
+                        {{ selectedTimeLong || "請選擇時段" }}
+                      </div>
+                    </div>
+                  </div>
+                </div>
+
+                <div class="text-sm font-semibold text-[#6E6E6A]">選擇時段</div>
+
+                <div class="rounded-2xl border border-[#E6E6DF] bg-white p-4">
+                  <div class="max-h-[320px] overflow-y-auto pr-2">
+                    <button
+                      v-for="t in timeOptions"
+                      :key="t.time"
+                      type="button"
+                      class="mb-3 flex w-full items-center justify-between rounded-2xl border px-5 py-4 text-left transition"
+                      :class="timeRowClass(t.time)"
+                      @click="selectedTime = t.time"
+                    >
+                      <div class="flex items-center gap-3">
+                        <span :class="selectedTime === t.time ? 'text-white' : 'text-[#6E6E6A]'" class="shrink-0">
+                          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                            <path d="M12 22a10 10 0 1 0 0-20 10 10 0 0 0 0 20z" stroke="currentColor" stroke-width="2" />
+                            <path
+                              d="M12 6v6l4 2"
+                              stroke="currentColor"
+                              stroke-width="2"
+                              stroke-linecap="round"
+                              stroke-linejoin="round"
+                            />
+                          </svg>
+                        </span>
+
+                        <div class="text-base font-bold" :class="selectedTime === t.time ? 'text-white' : 'text-[#2B2B2B]'">
+                          {{ t.time }}
+                        </div>
+                      </div>
+
+                      <div class="text-sm font-semibold" :class="selectedTime === t.time ? 'text-white/90' : 'text-[#7A7A7A]'">
+                        剩餘 {{ t.remain }}
+                      </div>
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Step 4 -->
+          <div v-else-if="step === 4">
+            <h2 class="text-3xl font-bold tracking-tight">聯絡資訊</h2>
+
+            <div class="mt-10 rounded-2xl border border-[#E6E6DF] bg-white px-10 py-6">
+              <div class="grid grid-cols-[44px_1fr] gap-6 py-7">
+                <div class="pt-1 text-[#6E6E6A]">
+                  <svg width="26" height="26" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                    <path d="M20 21a8 8 0 1 0-16 0" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+                    <path d="M12 13a4 4 0 1 0 0-8 4 4 0 0 0 0 8z" stroke="currentColor" stroke-width="2" />
+                  </svg>
+                </div>
+                <div>
+                  <div class="text-base font-semibold text-[#6E6E6A]">姓名</div>
+                  <input
+                    v-model.trim="contactName"
+                    class="mt-3 h-11 w-full rounded-xl bg-[#F5F4EF] px-4 text-sm outline-none placeholder:text-[#B5B5AD]"
+                    placeholder="請輸入姓名"
+                  />
+                </div>
+              </div>
+
+              <div class="h-px bg-[#E6E6DF]" />
+
+              <div class="grid grid-cols-[44px_1fr] gap-6 py-7">
+                <div class="pt-1 text-[#6E6E6A]">
+                  <svg width="26" height="26" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                    <path
+                      d="M22 16.92v3a2 2 0 0 1-2.18 2A19.8 19.8 0 0 1 3 5.18 2 2 0 0 1 5.11 3h3a2 2 0 0 1 2 1.72c.12.86.32 1.7.59 2.5a2 2 0 0 1-.45 2.11L9.1 10.9a16 16 0 0 0 4 4l1.57-1.15a2 2 0 0 1 2.11-.45c.8.27 1.64.47 2.5.59A2 2 0 0 1 22 16.92z"
+                      stroke="currentColor"
+                      stroke-width="2"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    />
+                  </svg>
+                </div>
+                <div>
+                  <div class="text-base font-semibold text-[#6E6E6A]">電話</div>
+                  <input
+                    v-model.trim="contactPhone"
+                    inputmode="tel"
+                    class="mt-3 h-11 w-full rounded-xl bg-[#F5F4EF] px-4 text-sm outline-none placeholder:text-[#B5B5AD]"
+                    placeholder="請輸入電話"
+                  />
+                </div>
+              </div>
+
+              <div class="h-px bg-[#E6E6DF]" />
+
+              <div class="grid grid-cols-[44px_1fr] gap-6 py-7">
+                <div class="pt-1 text-[#6E6E6A]">
+                  <svg width="26" height="26" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                    <path
+                      d="M4 4h16a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2z"
+                      stroke="currentColor"
+                      stroke-width="2"
+                      stroke-linecap="round"
+                    />
+                    <path
+                      d="m22 7-10 7L2 7"
+                      stroke="currentColor"
+                      stroke-width="2"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    />
+                  </svg>
+                </div>
+                <div>
+                  <div class="text-base font-semibold text-[#6E6E6A]">電子郵件</div>
+                  <input
+                    v-model.trim="contactEmail"
+                    inputmode="email"
+                    class="mt-3 h-11 w-full rounded-xl bg-[#F5F4EF] px-4 text-sm outline-none placeholder:text-[#B5B5AD]"
+                    placeholder="請輸入電子郵件"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Step 5 -->
+          <div v-else>
+            <h2 class="text-3xl font-bold tracking-tight">確認預約資訊</h2>
+
+            <div class="mt-10 rounded-2xl border border-[#E6E6DF] bg-white px-10 py-2">
+              <div class="grid grid-cols-[44px_1fr] gap-6 py-8">
+                <div class="pt-1 text-[#6E6E6A]">
+                  <svg width="26" height="26" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                    <path
+                      d="M14.7 6.3a4 4 0 0 0-5.4 5.4L3 18l3 3 6.3-6.3a4 4 0 0 0 5.4-5.4l-2.2 2.2-2-2 2.2-2.2z"
+                      stroke="currentColor"
+                      stroke-width="2"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    />
+                  </svg>
+                </div>
+                <div>
+                  <div class="text-base font-semibold text-[#6E6E6A]">服務項目</div>
+                  <div class="mt-2 text-lg font-semibold">{{ selectedServiceObj?.title || "—" }}</div>
+                  <div class="mt-2 text-sm text-[#7A7A7A]">預估時間：{{ selectedServiceObj?.minutes ?? "—" }}分鐘</div>
+                </div>
+              </div>
+
+              <div class="h-px bg-[#E6E6DF]" />
+
+              <div class="grid grid-cols-[44px_1fr] gap-6 py-8">
+                <div class="pt-1 text-[#6E6E6A]">
+                  <svg width="26" height="26" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                    <path
+                      d="M3 13l1.5-5A2 2 0 0 1 6.4 6h11.2a2 2 0 0 1 1.9 2L21 13"
+                      stroke="currentColor"
+                      stroke-width="2"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    />
+                    <path
+                      d="M5 13h14v6a1 1 0 0 1-1 1h-1a1 1 0 0 1-1-1v-1H8v1a1 1 0 0 1-1 1H6a1 1 0 0 1-1-1v-6z"
+                      stroke="currentColor"
+                      stroke-width="2"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    />
+                    <path d="M7.5 16.5h.01M16.5 16.5h.01" stroke="currentColor" stroke-width="3" stroke-linecap="round" />
+                  </svg>
+                </div>
+                <div>
+                  <div class="text-base font-semibold text-[#6E6E6A]">車輛類型</div>
+                  <div class="mt-2 text-lg font-semibold">{{ selectedVehicleObj?.title || "—" }}</div>
+                </div>
+              </div>
+
+              <div class="h-px bg-[#E6E6DF]" />
+
+              <div class="grid grid-cols-[44px_1fr] gap-6 py-8">
+                <div class="pt-1 text-[#6E6E6A]">
+                  <svg width="26" height="26" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                    <path
+                      d="M8 2v3M16 2v3M3.5 9h17M6 5h12a2 2 0 0 1 2 2v13a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V7a2 2 0 0 1 2-2z"
+                      stroke="currentColor"
+                      stroke-width="2"
+                      stroke-linecap="round"
+                    />
+                  </svg>
+                </div>
+                <div>
+                  <div class="text-base font-semibold text-[#6E6E6A]">預約日期 &amp; 時段</div>
+                  <div class="mt-2 text-lg font-semibold">{{ selectedDateLong || "—" }}</div>
+                  <div class="mt-2 text-lg font-semibold text-[#7A7A7A]">{{ selectedTimeLong || "—" }}</div>
+                </div>
+              </div>
+
+              <div class="h-px bg-[#E6E6DF]" />
+
+              <div class="grid grid-cols-[44px_1fr] gap-6 py-8">
+                <div class="pt-1 text-[#6E6E6A]">
+                  <svg width="26" height="26" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                    <path d="M20 21a8 8 0 1 0-16 0" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+                    <path d="M12 13a4 4 0 1 0 0-8 4 4 0 0 0 0 8z" stroke="currentColor" stroke-width="2" />
+                  </svg>
+                </div>
+                <div>
+                  <div class="text-base font-semibold text-[#6E6E6A]">姓名</div>
+                  <div class="mt-2 text-lg font-semibold">{{ contactName || "—" }}</div>
+                </div>
+              </div>
+
+              <div class="h-px bg-[#E6E6DF]" />
+
+              <div class="grid grid-cols-[44px_1fr] gap-6 py-8">
+                <div class="pt-1 text-[#6E6E6A]">
+                  <svg width="26" height="26" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                    <path
+                      d="M22 16.92v3a2 2 0 0 1-2.18 2A19.8 19.8 0 0 1 3 5.18 2 2 0 0 1 5.11 3h3a2 2 0 0 1 2 1.72c.12.86.32 1.7.59 2.5a2 2 0 0 1-.45 2.11L9.1 10.9a16 16 0 0 0 4 4l1.57-1.15a2 2 0 0 1 2.11-.45c.8.27 1.64.47 2.5.59A2 2 0 0 1 22 16.92z"
+                      stroke="currentColor"
+                      stroke-width="2"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    />
+                  </svg>
+                </div>
+                <div>
+                  <div class="text-base font-semibold text-[#6E6E6A]">電話</div>
+                  <div class="mt-2 text-lg font-semibold">{{ contactPhone || "—" }}</div>
+                </div>
+              </div>
+
+              <div class="h-px bg-[#E6E6DF]" />
+
+              <div class="grid grid-cols-[44px_1fr] gap-6 py-8">
+                <div class="pt-1 text-[#6E6E6A]">
+                  <svg width="26" height="26" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                    <path
+                      d="M4 4h16a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2z"
+                      stroke="currentColor"
+                      stroke-width="2"
+                      stroke-linecap="round"
+                    />
+                    <path
+                      d="m22 7-10 7L2 7"
+                      stroke="currentColor"
+                      stroke-width="2"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    />
+                  </svg>
+                </div>
+                <div>
+                  <div class="text-base font-semibold text-[#6E6E6A]">電子郵件</div>
+                  <div class="mt-2 text-lg font-semibold">{{ contactEmail || "—" }}</div>
+                </div>
               </div>
             </div>
           </div>
         </div>
 
-        <!-- Other Steps Placeholder -->
-        <div
-          v-else
-          class="flex flex-col items-center justify-center flex-1 h-64 text-gray-400 border-2 border-dashed rounded-xl"
-        >
-          <i class="mb-4 text-4xl fa-solid fa-person-digging"></i>
-          <p>步驟 {{ currentStep }} 內容建置中...</p>
-        </div>
-
-        <!-- Navigation -->
-        <div class="flex justify-between mt-12 pt-6 border-t border-gray-100">
+        <!-- Bottom actions -->
+        <div class="mt-14 flex items-center justify-between">
           <button
-            @click="currentStep > 1 && currentStep--"
-            :disabled="currentStep === 1"
-            class="px-8 py-3 text-sm font-medium transition-colors border border-gray-200 rounded disabled:opacity-50 disabled:cursor-not-allowed hover:bg-gray-50 text-gray-500"
+            type="button"
+            class="rounded-xl border px-10 py-3 text-sm font-semibold transition"
+            :class="prevBtnClass"
+            :disabled="step === 1"
+            @click="prevStep"
           >
             上一步
           </button>
 
           <button
-            @click="currentStep < 5 && currentStep++"
-            class="px-8 py-3 text-sm font-medium text-white transition-colors rounded shadow-md bg-[#6b635c] hover:bg-[#5a534d]"
+            v-if="step < 5"
+            type="button"
+            class="rounded-xl px-10 py-3 text-sm font-semibold text-white transition"
+            :class="nextBtnClass"
+            :disabled="!canGoNext"
+            @click="nextStep"
           >
             下一步
           </button>
-        </div>
 
+          <button
+            v-else
+            type="button"
+            class="rounded-xl bg-[#6E6E6A] px-10 py-3 text-sm font-semibold text-white shadow-[0_3px_0_rgba(0,0,0,0.18)] hover:opacity-95 active:opacity-90"
+            :disabled="!canFinish"
+            @click="finish"
+          >
+            完成預約
+          </button>
+        </div>
       </div>
-    </main>
+    </div>
+
+    <!-- Success overlay (改成你提供的樣式) -->
+    <div v-if="showSuccess" class="fixed inset-0 z-50 bg-black/40">
+      <div class="absolute inset-0 flex items-center justify-center p-6">
+        <div
+          class="relative w-full max-w-[680px] rounded-2xl border border-[#E6E6DF] bg-[#FBFAF7] shadow-[0_20px_60px_rgba(0,0,0,0.25)]"
+        >
+          <!-- close -->
+          <button
+            type="button"
+            class="absolute right-5 top-5 text-[#6E6E6A] hover:opacity-80"
+            aria-label="close"
+            @click="showSuccess = false"
+          >
+            ✕
+          </button>
+
+          <div class="px-10 pb-10 pt-12 text-center">
+            <!-- icon circle -->
+            <div class="mx-auto grid h-20 w-20 place-items-center rounded-full bg-[#F2F1EC]">
+              <svg width="44" height="44" viewBox="0 0 24 24" fill="none" aria-hidden="true" class="text-[#6E6E6A]">
+                <path
+                  d="M22 11.08V12a10 10 0 1 1-5.93-9.14"
+                  stroke="currentColor"
+                  stroke-width="2.2"
+                  stroke-linecap="round"
+                />
+                <path
+                  d="M22 4 12 14.01l-3-3"
+                  stroke="currentColor"
+                  stroke-width="2.2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+            </div>
+
+            <div class="mt-6 text-3xl font-extrabold">預約成功！</div>
+            <div class="mt-3 text-lg font-semibold text-[#7A7A7A]">您的預約已送出</div>
+
+            <!-- booking code card -->
+            <div class="mx-auto mt-8 w-full max-w-[260px] rounded-2xl border border-[#E6E6DF] bg-[#F6F5F0] px-6 py-5">
+              <div class="text-sm font-semibold text-[#7A7A7A]">預約編號</div>
+              <div class="mt-2 text-lg font-extrabold tracking-wide text-[#2B2B2B]">
+                {{ bookingCode }}
+              </div>
+            </div>
+
+            <div class="mt-8 text-sm leading-7 text-[#7A7A7A]">
+              我們已發送確認信至您的電子郵件，請留意相關通知。
+            </div>
+
+            <button
+              type="button"
+              class="mt-8 w-full rounded-xl bg-[#6E6E6A] px-6 py-4 text-base font-bold text-white hover:opacity-95 active:opacity-90"
+              @click="resetAll"
+            >
+              再次預約
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
 </template>
+
+<script setup lang="ts">
+import { computed, ref } from "vue";
+
+/** Steps */
+type StepKey = "service" | "vehicle" | "datetime" | "contact" | "confirm";
+const steps: Array<{ key: StepKey; label: string }> = [
+  { key: "service", label: "選擇服務" },
+  { key: "vehicle", label: "車輛類型" },
+  { key: "datetime", label: "日期時段" },
+  { key: "contact", label: "聯絡資訊" },
+  { key: "confirm", label: "確認預約" },
+];
+
+const step = ref<number>(1);
+
+/** Step 1 */
+type ServiceKey = "oil" | "tire" | "brake" | "maintain";
+const serviceOptions: Array<{ key: ServiceKey; title: string; minutes: number; icon: string }> = [
+  { key: "oil", title: "機油更換", minutes: 30, icon: "🛠️" },
+  { key: "tire", title: "輪胎檢修", minutes: 45, icon: "🚗" },
+  { key: "brake", title: "煞車系統檢查", minutes: 60, icon: "✅" },
+  { key: "maintain", title: "定期保養", minutes: 90, icon: "🔧" },
+];
+const selectedService = ref<ServiceKey | null>(null);
+
+/** Step 2 */
+type VehicleKey = "sedan" | "suv" | "truck" | "motor";
+const vehicleOptions: Array<{ key: VehicleKey; title: string; subtitle: string }> = [
+  { key: "sedan", title: "轎車", subtitle: "一般房車" },
+  { key: "suv", title: "SUV/休旅車", subtitle: "運動休旅車" },
+  { key: "truck", title: "貨車", subtitle: "小型貨車" },
+  { key: "motor", title: "機車", subtitle: "機車類" },
+];
+const selectedVehicle = ref<VehicleKey | null>(null);
+
+/** Step 3 */
+const weekDaysMon = ["一", "二", "三", "四", "五", "六", "日"];
+const monthOptions = ["一月", "二月", "三月", "四月", "五月", "六月", "七月", "八月", "九月", "十月", "十一月", "十二月"];
+
+const viewYear = ref<number>(2026);
+const viewMonth = ref<number>(0); // Jan
+const selectedDate = ref<Date | null>(null);
+const selectedTime = ref<string | null>(null);
+
+const yearOptions = computed(() => [2025, 2026, 2027, 2028]);
+const timeOptions = [
+  { time: "09:00", remain: 3 },
+  { time: "10:00", remain: 5 },
+  { time: "11:00", remain: 2 },
+  { time: "13:00", remain: 4 },
+  { time: "14:00", remain: 1 },
+  { time: "15:00", remain: 6 },
+];
+
+/** Step 4 contact */
+const contactName = ref<string>("");
+const contactPhone = ref<string>("");
+const contactEmail = ref<string>("");
+
+const isContactValid = computed(() => {
+  return !!contactName.value.trim() && !!contactPhone.value.trim() && !!contactEmail.value.trim();
+});
+
+/** Unlock logic */
+const maxUnlocked = computed(() => {
+  if (step.value === 1) return selectedService.value ? 2 : 1;
+  if (step.value === 2) return selectedVehicle.value ? 3 : 2;
+  if (step.value === 3) return selectedDate.value && selectedTime.value ? 4 : 3;
+  if (step.value === 4) return isContactValid.value ? 5 : 4;
+  return 5;
+});
+
+const goToStep = (n: number) => {
+  const target = Math.min(5, Math.max(1, n));
+  step.value = Math.min(target, maxUnlocked.value);
+};
+
+const nextStep = () => {
+  if (!canGoNext.value) return;
+  step.value = Math.min(5, step.value + 1);
+};
+
+const prevStep = () => {
+  step.value = Math.max(1, step.value - 1);
+};
+
+const canGoNext = computed(() => {
+  if (step.value === 1) return selectedService.value !== null;
+  if (step.value === 2) return selectedVehicle.value !== null;
+  if (step.value === 3) return selectedDate.value !== null && selectedTime.value !== null;
+  if (step.value === 4) return isContactValid.value;
+  return true;
+});
+
+const canFinish = computed(() => {
+  return (
+    selectedService.value !== null &&
+    selectedVehicle.value !== null &&
+    selectedDate.value !== null &&
+    selectedTime.value !== null &&
+    isContactValid.value
+  );
+});
+
+/** Progress overlay */
+const progressWidth = computed(() => {
+  const segments = steps.length - 1;
+  const done = Math.max(0, step.value - 1);
+  return `${(done / segments) * 100}%`;
+});
+
+/** Stepper UI */
+const circleClass = (n: number) => {
+  if (n <= step.value) return "bg-[#6E6E6A] text-white";
+  return "bg-white text-[#7A7A7A] border border-[#E6E6DF]";
+};
+const labelClass = (n: number) => {
+  if (n === step.value) return "text-[#2B2B2B] font-semibold";
+  return "text-[#7A7A7A]";
+};
+
+/** Cards */
+const serviceCardClass = (key: ServiceKey) => {
+  return selectedService.value === key ? "border-[#6E6E6A]" : "border-[#E6E6DF] hover:border-[#CFCFC6]";
+};
+const vehicleCardClass = (key: VehicleKey) => {
+  return selectedVehicle.value === key
+    ? "border-[#6E6E6A] bg-[#FAFAF8]"
+    : "border-[#E6E6DF] bg-white hover:border-[#CFCFC6]";
+};
+
+/** Buttons */
+const prevBtnClass = computed(() => {
+  return step.value === 1
+    ? "border-[#E6E6DF] text-[#B5B5AD] bg-[#FBFAF7] cursor-not-allowed"
+    : "border-[#E6E6DF] text-[#6E6E6A] bg-[#FBFAF7] hover:bg-white";
+});
+const nextBtnClass = computed(() => {
+  return canGoNext.value
+    ? "bg-[#6E6E6A] hover:opacity-95 active:opacity-90 shadow-[0_3px_0_rgba(0,0,0,0.18)]"
+    : "bg-[#D1D1CB] cursor-not-allowed";
+});
+
+/** Calendar helpers */
+const toMonIndex = (jsDay: number) => (jsDay + 6) % 7;
+
+const calendarCellsMon42 = computed(() => {
+  const first = new Date(viewYear.value, viewMonth.value, 1);
+  const firstMonIdx = toMonIndex(first.getDay());
+  const start = new Date(viewYear.value, viewMonth.value, 1 - firstMonIdx);
+
+  const cells: Array<{ key: string; date: Date; inMonth: boolean }> = [];
+  for (let i = 0; i < 42; i++) {
+    const d = new Date(start);
+    d.setDate(start.getDate() + i);
+    cells.push({
+      key: `${d.getFullYear()}-${d.getMonth()}-${d.getDate()}`,
+      date: d,
+      inMonth: d.getMonth() === viewMonth.value,
+    });
+  }
+  return cells;
+});
+
+const sameDay = (a: Date, b: Date) =>
+  a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth() && a.getDate() === b.getDate();
+
+const dayBtnClass = (d: Date, inMonth: boolean) => {
+  const sel = selectedDate.value && sameDay(d, selectedDate.value);
+  if (sel) return "bg-[#6E6E6A] text-white";
+  if (!inMonth) return "text-[#D1D1CB] hover:bg-transparent";
+  return "text-[#2B2B2B] hover:bg-[#F5F4EF]";
+};
+
+const onPickDate = (d: Date) => {
+  selectedDate.value = new Date(d);
+};
+
+const prevMonth = () => {
+  if (viewMonth.value === 0) {
+    viewMonth.value = 11;
+    viewYear.value -= 1;
+  } else {
+    viewMonth.value -= 1;
+  }
+};
+const nextMonth = () => {
+  if (viewMonth.value === 11) {
+    viewMonth.value = 0;
+    viewYear.value += 1;
+  } else {
+    viewMonth.value += 1;
+  }
+};
+
+/** Long date/time */
+const weekdayCN = ["星期日", "星期一", "星期二", "星期三", "星期四", "星期五", "星期六"];
+const pad2 = (n: number) => String(n).padStart(2, "0");
+
+const selectedDateLong = computed(() => {
+  if (!selectedDate.value) return "";
+  const y = selectedDate.value.getFullYear();
+  const m = pad2(selectedDate.value.getMonth() + 1);
+  const d = pad2(selectedDate.value.getDate());
+  const w = weekdayCN[selectedDate.value.getDay()];
+  return `${y}年 ${m}月 ${d}日 ${w}`;
+});
+
+const selectedTimeLong = computed(() => {
+  if (!selectedTime.value) return "";
+  const hour = Number(selectedTime.value.split(":")[0] || 0);
+  const period = hour < 12 ? "早上" : hour < 18 ? "下午" : "晚上";
+  return `${selectedTime.value} ${period}`;
+});
+
+const timeRowClass = (t: string) => {
+  const active = selectedTime.value === t;
+  return active ? "border-transparent bg-[#6E6E6A]" : "border-[#E6E6DF] bg-white hover:border-[#CFCFC6]";
+};
+
+/** Step 5 display helpers */
+const selectedServiceObj = computed(() => serviceOptions.find((s) => s.key === selectedService.value) || null);
+const selectedVehicleObj = computed(() => vehicleOptions.find((v) => v.key === selectedVehicle.value) || null);
+
+/** Success dialog */
+const showSuccess = ref(false);
+const bookingCode = ref<string>("");
+
+const randomBookingCode = () => {
+  // BK + 8 digits
+  const n = Math.floor(10000000 + Math.random() * 90000000);
+  return `BK${n}`;
+};
+
+const finish = () => {
+  if (!canFinish.value) return;
+  bookingCode.value = randomBookingCode();
+  showSuccess.value = true;
+};
+
+const resetAll = () => {
+  showSuccess.value = false;
+
+  // reset flow
+  step.value = 1;
+  selectedService.value = null;
+  selectedVehicle.value = null;
+  selectedDate.value = null;
+  selectedTime.value = null;
+
+  contactName.value = "";
+  contactPhone.value = "";
+  contactEmail.value = "";
+
+  // keep view year/month as is (也可以改回預設)
+};
+</script>

--- a/src/components/service-search/ServiceModal.vue
+++ b/src/components/service-search/ServiceModal.vue
@@ -15,7 +15,7 @@ defineEmits<{
       >
         <button
           type="button"
-          class="absolute right-5 top-5 text-[#6E6E6A] hover:opacity-80"
+          class="absolute right-5 top-5 text-[#6B6B5C] hover:opacity-80"
           aria-label="close"
           @click="$emit('close')"
         >
@@ -23,7 +23,7 @@ defineEmits<{
         </button>
 
         <div class="px-10 pb-10 pt-12 text-center">
-          <div class="mx-auto grid h-20 w-20 place-items-center rounded-full bg-[#F2F1EC] text-[#6E6E6A]">
+          <div class="mx-auto grid h-20 w-20 place-items-center rounded-full bg-[#F2F1EC] text-[#6B6B5C]">
             <i class="fa-regular fa-circle-check text-4xl" aria-hidden="true"></i>
           </div>
 
@@ -43,7 +43,7 @@ defineEmits<{
 
           <button
             type="button"
-            class="mt-8 w-full rounded-xl bg-[#6E6E6A] px-6 py-4 text-base font-bold text-white hover:opacity-95 active:opacity-90"
+            class="mt-8 w-full rounded-xl bg-[#6B6B5C] px-6 py-4 text-base font-bold text-white hover:opacity-95 active:opacity-90"
             @click="$emit('again')"
           >
             再次預約

--- a/src/components/service-search/ServiceModal.vue
+++ b/src/components/service-search/ServiceModal.vue
@@ -41,7 +41,7 @@ defineEmits<{
             class="mt-8 w-full rounded-xl bg-[#6B6B5C] px-6 py-4 text-base font-bold text-white hover:opacity-95 active:opacity-90"
             @click="$emit('again')"
           >
-            再次預約
+            查看預約狀態
           </button>
         </div>
       </div>

--- a/src/components/service-search/ServiceModal.vue
+++ b/src/components/service-search/ServiceModal.vue
@@ -21,26 +21,21 @@ defineEmits<{
         >
           <i class="fa-solid fa-xmark text-xl" aria-hidden="true"></i>
         </button>
-
         <div class="px-10 pb-10 pt-12 text-center">
           <div class="mx-auto grid h-20 w-20 place-items-center rounded-full bg-[#F2F1EC] text-[#6B6B5C]">
             <i class="fa-regular fa-circle-check text-4xl" aria-hidden="true"></i>
           </div>
-
           <div class="mt-6 text-3xl font-extrabold">預約成功！</div>
           <div class="mt-3 text-lg font-semibold text-[#7A7A7A]">您的預約已送出</div>
-
           <div class="mx-auto mt-8 w-full max-w-[260px] rounded-2xl border border-[#E6E6DF] bg-[#F6F5F0] px-6 py-5">
             <div class="text-sm font-semibold text-[#7A7A7A]">預約編號</div>
             <div class="mt-2 text-lg font-extrabold tracking-wide text-[#2B2B2B]">
               {{ bookingCode }}
             </div>
           </div>
-
           <div class="mt-8 text-sm leading-7 text-[#7A7A7A]">
             我們已發送確認信至您的電子郵件，請留意相關通知。
           </div>
-
           <button
             type="button"
             class="mt-8 w-full rounded-xl bg-[#6B6B5C] px-6 py-4 text-base font-bold text-white hover:opacity-95 active:opacity-90"

--- a/src/components/service-search/ServiceModal.vue
+++ b/src/components/service-search/ServiceModal.vue
@@ -1,0 +1,55 @@
+<script setup lang="ts">
+defineProps<{ bookingCode: string }>();
+
+defineEmits<{
+  (e: "close"): void;
+  (e: "again"): void;
+}>();
+</script>
+
+<template>
+  <div class="fixed inset-0 z-50 bg-black/40">
+    <div class="absolute inset-0 flex items-center justify-center p-6">
+      <div
+        class="relative w-full max-w-[680px] rounded-2xl border border-[#E6E6DF] bg-[#FBFAF7] shadow-[0_20px_60px_rgba(0,0,0,0.25)]"
+      >
+        <button
+          type="button"
+          class="absolute right-5 top-5 text-[#6E6E6A] hover:opacity-80"
+          aria-label="close"
+          @click="$emit('close')"
+        >
+          <i class="fa-solid fa-xmark text-xl" aria-hidden="true"></i>
+        </button>
+
+        <div class="px-10 pb-10 pt-12 text-center">
+          <div class="mx-auto grid h-20 w-20 place-items-center rounded-full bg-[#F2F1EC] text-[#6E6E6A]">
+            <i class="fa-regular fa-circle-check text-4xl" aria-hidden="true"></i>
+          </div>
+
+          <div class="mt-6 text-3xl font-extrabold">預約成功！</div>
+          <div class="mt-3 text-lg font-semibold text-[#7A7A7A]">您的預約已送出</div>
+
+          <div class="mx-auto mt-8 w-full max-w-[260px] rounded-2xl border border-[#E6E6DF] bg-[#F6F5F0] px-6 py-5">
+            <div class="text-sm font-semibold text-[#7A7A7A]">預約編號</div>
+            <div class="mt-2 text-lg font-extrabold tracking-wide text-[#2B2B2B]">
+              {{ bookingCode }}
+            </div>
+          </div>
+
+          <div class="mt-8 text-sm leading-7 text-[#7A7A7A]">
+            我們已發送確認信至您的電子郵件，請留意相關通知。
+          </div>
+
+          <button
+            type="button"
+            class="mt-8 w-full rounded-xl bg-[#6E6E6A] px-6 py-4 text-base font-bold text-white hover:opacity-95 active:opacity-90"
+            @click="$emit('again')"
+          >
+            再次預約
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/components/service-search/ServiceSearchFlow.vue
+++ b/src/components/service-search/ServiceSearchFlow.vue
@@ -34,7 +34,7 @@ const viewMonth = ref<number>(0); // Jan
 const selectedDate = ref<Date | null>(null);
 const selectedTime = ref<string | null>(null);
 
-const yearOptions = computed(() => [2025, 2026, 2027, 2028]);
+const yearOptions = computed(() => [2026, 2027, 2028]);
 const timeOptions = [
   { time: "09:00", remain: 3 },
   { time: "10:00", remain: 5 },

--- a/src/components/service-search/ServiceSearchFlow.vue
+++ b/src/components/service-search/ServiceSearchFlow.vue
@@ -1,5 +1,235 @@
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import ServiceStepper from "./ServiceStepper.vue";
+import ServiceModal from "./ServiceModal.vue";
+
+// 定義 emit，讓父層可以監聽 'back' 事件來處理返回邏輯
+defineEmits<{
+  (e: "back"): void;
+}>();
+
+/** Steps - 維持 4 步驟 (已移除 vehicle) */
+type StepKey = "service" | "datetime" | "contact" | "confirm";
+const steps: Array<{ key: StepKey; label: string }> = [
+  { key: "service", label: "選擇服務" },
+  { key: "datetime", label: "日期時段" },
+  { key: "contact", label: "聯絡資訊" },
+  { key: "confirm", label: "確認預約" },
+];
+
+const step = ref<number>(1);
+
+type ServiceKey = "oil" | "tire" | "brake" | "maintain";
+const serviceOptions: Array<{ key: ServiceKey; title: string; minutes: number; fa: string }> = [
+  { key: "oil", title: "機油更換", minutes: 30, fa: "fa-solid fa-oil-can" },
+  { key: "tire", title: "輪胎檢修", minutes: 45, fa: "fa-solid fa-car-side" },
+  { key: "brake", title: "煞車系統檢查", minutes: 60, fa: "fa-solid fa-circle-check" },
+  { key: "maintain", title: "定期保養", minutes: 90, fa: "fa-solid fa-screwdriver-wrench" },
+];
+const selectedService = ref<ServiceKey | null>(null);
+
+const weekDaysMon = ["一", "二", "三", "四", "五", "六", "日"];
+const monthOptions = ["一月", "二月", "三月", "四月", "五月", "六月", "七月", "八月", "九月", "十月", "十一月", "十二月"];
+
+const viewYear = ref<number>(2026);
+const viewMonth = ref<number>(0); // Jan
+const selectedDate = ref<Date | null>(null);
+const selectedTime = ref<string | null>(null);
+
+const yearOptions = computed(() => [2025, 2026, 2027, 2028]);
+const timeOptions = [
+  { time: "09:00", remain: 3 },
+  { time: "10:00", remain: 5 },
+  { time: "11:00", remain: 2 },
+  { time: "13:00", remain: 4 },
+  { time: "14:00", remain: 1 },
+  { time: "15:00", remain: 6 },
+];
+
+const contactName = ref<string>("");
+const contactPhone = ref<string>("");
+const contactEmail = ref<string>("");
+const contactNote = ref<string>("");
+
+const isContactValid = computed(() => {
+  return !!contactName.value.trim() && !!contactPhone.value.trim() && !!contactEmail.value.trim();
+});
+
+// 邏輯調整：總共 4 步
+const maxUnlocked = computed(() => {
+  if (step.value === 1) return selectedService.value ? 2 : 1;
+  if (step.value === 2) return selectedDate.value && selectedTime.value ? 3 : 2;
+  if (step.value === 3) return isContactValid.value ? 4 : 3;
+  return 4;
+});
+
+const goToStep = (n: number) => {
+  const target = Math.min(4, Math.max(1, n));
+  step.value = Math.min(target, maxUnlocked.value);
+};
+
+const nextStep = () => {
+  if (!canGoNext.value) return;
+  step.value = Math.min(4, step.value + 1);
+};
+
+const prevStep = () => {
+  step.value = Math.max(1, step.value - 1);
+};
+
+const canGoNext = computed(() => {
+  if (step.value === 1) return selectedService.value !== null;
+  if (step.value === 2) return selectedDate.value !== null && selectedTime.value !== null;
+  if (step.value === 3) return isContactValid.value;
+  return true;
+});
+
+const canFinish = computed(() => {
+  return (
+    selectedService.value !== null &&
+    selectedDate.value !== null &&
+    selectedTime.value !== null &&
+    isContactValid.value
+  );
+});
+
+const serviceCardClass = (key: ServiceKey) => {
+  return selectedService.value === key
+    ? "border-[#6B6B5C] bg-[#6B6B5C] shadow-[0_3px_0_rgba(0,0,0,0.18)]"
+    : "border-[#E6E6DF] bg-white hover:border-[#CFCFC6]";
+};
+
+const prevBtnClass = computed(() => {
+  return step.value === 1
+    ? "border-[#E6E6DF] text-[#B5B5AD] bg-[#FBFAF7] cursor-not-allowed"
+    : "border-[#E6E6DF] text-[#6B6B5C] bg-[#FBFAF7] hover:bg-white";
+});
+const nextBtnClass = computed(() => {
+  return canGoNext.value
+    ? "bg-[#6B6B5C] hover:opacity-95 active:opacity-90 shadow-[0_3px_0_rgba(0,0,0,0.18)]"
+    : "bg-[#D1D1CB] cursor-not-allowed";
+});
+
+const toMonIndex = (jsDay: number) => (jsDay + 6) % 7;
+
+const calendarCellsMon42 = computed(() => {
+  const first = new Date(viewYear.value, viewMonth.value, 1);
+  const firstMonIdx = toMonIndex(first.getDay());
+  const start = new Date(viewYear.value, viewMonth.value, 1 - firstMonIdx);
+
+  const cells: Array<{ key: string; date: Date; inMonth: boolean }> = [];
+  for (let i = 0; i < 42; i++) {
+    const d = new Date(start);
+    d.setDate(start.getDate() + i);
+    cells.push({
+      key: `${d.getFullYear()}-${d.getMonth()}-${d.getDate()}`,
+      date: d,
+      inMonth: d.getMonth() === viewMonth.value,
+    });
+  }
+  return cells;
+});
+
+const sameDay = (a: Date, b: Date) =>
+  a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth() && a.getDate() === b.getDate();
+
+const dayBtnClass = (d: Date, inMonth: boolean) => {
+  const sel = selectedDate.value && sameDay(d, selectedDate.value);
+  if (sel) return "bg-[#6B6B5C] text-white";
+  if (!inMonth) return "text-[#D1D1CB] hover:bg-transparent";
+  return "text-[#2B2B2B] hover:bg-[#F5F4EF]";
+};
+
+const onPickDate = (d: Date) => {
+  selectedDate.value = new Date(d);
+};
+
+const prevMonth = () => {
+  if (viewMonth.value === 0) {
+    viewMonth.value = 11;
+    viewYear.value -= 1;
+  } else {
+    viewMonth.value -= 1;
+  }
+};
+const nextMonth = () => {
+  if (viewMonth.value === 11) {
+    viewMonth.value = 0;
+    viewYear.value += 1;
+  } else {
+    viewMonth.value += 1;
+  }
+};
+
+const weekdayCN = ["星期日", "星期一", "星期二", "星期三", "星期四", "星期五", "星期六"];
+const pad2 = (n: number) => String(n).padStart(2, "0");
+
+const selectedDateLong = computed(() => {
+  if (!selectedDate.value) return "";
+  const y = selectedDate.value.getFullYear();
+  const m = pad2(selectedDate.value.getMonth() + 1);
+  const d = pad2(selectedDate.value.getDate());
+  const w = weekdayCN[selectedDate.value.getDay()];
+  return `${y}年 ${m}月 ${d}日 ${w}`;
+});
+
+const selectedTimeLong = computed(() => {
+  if (!selectedTime.value) return "";
+  const hour = Number(selectedTime.value.split(":")[0] || 0);
+  const period = hour < 12 ? "早上" : hour < 18 ? "下午" : "晚上";
+  return `${selectedTime.value} ${period}`;
+});
+
+const timeRowClass = (t: string) => {
+  const active = selectedTime.value === t;
+  return active ? "border-transparent bg-[#6B6B5C]" : "border-[#E6E6DF] bg-white hover:border-[#CFCFC6]";
+};
+
+const selectedServiceObj = computed(() => serviceOptions.find((s) => s.key === selectedService.value) || null);
+
+const showSuccess = ref(false);
+const bookingCode = ref<string>("");
+
+const randomBookingCode = () => {
+  const n = Math.floor(10000000 + Math.random() * 90000000);
+  return `BK${n}`;
+};
+
+const finish = () => {
+  if (!canFinish.value) return;
+  bookingCode.value = randomBookingCode();
+  showSuccess.value = true;
+};
+
+const resetAll = () => {
+  showSuccess.value = false;
+
+  step.value = 1;
+  selectedService.value = null;
+  selectedDate.value = null;
+  selectedTime.value = null;
+
+  contactName.value = "";
+  contactPhone.value = "";
+  contactEmail.value = "";
+  contactNote.value = "";
+};
+</script>
+
 <template>
   <div class="min-h-screen bg-[#FAF8F5] px-6 py-10 text-[#2B2B2B]">
+    
+    <div class="mx-auto mb-6 w-full max-w-6xl">
+      <button
+        type="button"
+        class="flex items-center gap-2 rounded-xl border border-[#E6E6DF] bg-white px-6 py-3 text-sm font-semibold text-[#6B6B5C] transition hover:bg-[#F5F4EF]"
+        @click="$emit('back')"
+      >
+        <i class="fa-solid fa-arrow-left"></i>
+        返回店家介紹頁面
+      </button>
+    </div>
+
     <div class="mx-auto w-full max-w-6xl rounded-[28px] border border-[#E6E6DF] bg-white shadow-[0_2px_10px_rgba(0,0,0,0.06)]">
       <div class="p-10">
         <ServiceStepper :step="step" :steps="steps" @go="goToStep" />
@@ -29,35 +259,12 @@
                   >
                     {{ item.title }}
                   </div>
-                  </div>
-              </button>
-            </div>
-          </div>
-          <div v-else-if="step === 2">
-            <h2 class="text-3xl font-bold tracking-tight">選擇車輛類型</h2>
-            <div class="mt-10 grid grid-cols-2 gap-6">
-              <button
-                v-for="v in vehicleOptions"
-                :key="v.key"
-                type="button"
-                class="flex items-center gap-6 rounded-2xl border px-8 py-7 text-left transition"
-                :class="vehicleCardClass(v.key)"
-                @click="selectedVehicle = v.key"
-              >
-                <span
-                  class="relative grid h-5 w-5 place-items-center rounded-full border"
-                  :class="selectedVehicle === v.key ? 'border-[#6B6B5C]' : 'border-[#E6E6DF]'"
-                >
-                  <span v-if="selectedVehicle === v.key" class="h-2.5 w-2.5 rounded-full bg-[#6B6B5C]" />
-                </span>
-                <div>
-                  <div class="text-lg font-semibold">{{ v.title }}</div>
-                  <div class="mt-1 text-sm text-[#7A7A7A]">{{ v.subtitle }}</div>
                 </div>
               </button>
             </div>
           </div>
-          <div v-else-if="step === 3">
+          
+          <div v-else-if="step === 2">
             <h2 class="text-3xl font-bold tracking-tight">選擇日期</h2>
             <div class="mt-10 grid grid-cols-2 gap-8">
               <div class="rounded-2xl border border-[#E6E6DF] bg-white p-8">
@@ -167,7 +374,8 @@
               </div>
             </div>
           </div>
-          <div v-else-if="step === 4">
+
+          <div v-else-if="step === 3">
             <h2 class="text-3xl font-bold tracking-tight">聯絡資訊</h2>
             <div class="mt-10 rounded-2xl border border-[#E6E6DF] bg-white px-10 py-6">
               <div class="grid grid-cols-[44px_1fr] gap-6 py-7">
@@ -232,6 +440,7 @@
               </div>
             </div>
           </div>
+
           <div v-else>
             <h2 class="text-3xl font-bold tracking-tight">確認預約資訊</h2>
             <div class="mt-10 rounded-2xl border border-[#E6E6DF] bg-white px-10 py-2">
@@ -243,16 +452,6 @@
                   <div class="text-base font-semibold text-[#6B6B5C]">服務項目</div>
                   <div class="mt-2 text-lg font-semibold">{{ selectedServiceObj?.title || "—" }}</div>
                   <div class="mt-2 text-sm text-[#7A7A7A]">預估時間：{{ selectedServiceObj?.minutes ?? "—" }}分鐘</div>
-                </div>
-              </div>
-              <div class="h-px bg-[#E6E6DF]" />
-              <div class="grid grid-cols-[44px_1fr] gap-6 py-8">
-                <div class="pt-1 text-[#6B6B5C]">
-                  <i class="fa-solid fa-car text-2xl" aria-hidden="true"></i>
-                </div>
-                <div>
-                  <div class="text-base font-semibold text-[#6B6B5C]">車輛類型</div>
-                  <div class="mt-2 text-lg font-semibold">{{ selectedVehicleObj?.title || "—" }}</div>
                 </div>
               </div>
               <div class="h-px bg-[#E6E6DF]" />
@@ -322,7 +521,7 @@
             上一步
           </button>
           <button
-            v-if="step < 5"
+            v-if="step < 4"
             type="button"
             class="rounded-xl px-10 py-3 text-sm font-semibold text-white transition"
             :class="nextBtnClass"
@@ -346,236 +545,3 @@
         <ServiceModal v-if="showSuccess" :bookingCode="bookingCode" @close="showSuccess = false" @again="resetAll" />
   </div>
 </template>
-
-<script setup lang="ts">
-import { computed, ref } from "vue";
-import ServiceStepper from "./ServiceStepper.vue";
-import ServiceModal from "./ServiceModal.vue";
-
-/** Steps */
-type StepKey = "service" | "vehicle" | "datetime" | "contact" | "confirm";
-const steps: Array<{ key: StepKey; label: string }> = [
-  { key: "service", label: "選擇服務" },
-  { key: "vehicle", label: "車輛類型" },
-  { key: "datetime", label: "日期時段" },
-  { key: "contact", label: "聯絡資訊" },
-  { key: "confirm", label: "確認預約" },
-];
-
-const step = ref<number>(1);
-
-type ServiceKey = "oil" | "tire" | "brake" | "maintain";
-const serviceOptions: Array<{ key: ServiceKey; title: string; minutes: number; fa: string }> = [
-  { key: "oil", title: "機油更換", minutes: 30, fa: "fa-solid fa-oil-can" },
-  { key: "tire", title: "輪胎檢修", minutes: 45, fa: "fa-solid fa-car-side" },
-  { key: "brake", title: "煞車系統檢查", minutes: 60, fa: "fa-solid fa-circle-check" },
-  { key: "maintain", title: "定期保養", minutes: 90, fa: "fa-solid fa-screwdriver-wrench" },
-];
-const selectedService = ref<ServiceKey | null>(null);
-
-type VehicleKey = "sedan" | "suv" | "truck" | "motor";
-const vehicleOptions: Array<{ key: VehicleKey; title: string; subtitle: string }> = [
-  { key: "sedan", title: "轎車", subtitle: "一般房車" },
-  { key: "suv", title: "SUV/休旅車", subtitle: "運動休旅車" },
-  { key: "truck", title: "貨車", subtitle: "小型貨車" },
-  { key: "motor", title: "機車", subtitle: "機車類" },
-];
-const selectedVehicle = ref<VehicleKey | null>(null);
-
-const weekDaysMon = ["一", "二", "三", "四", "五", "六", "日"];
-const monthOptions = ["一月", "二月", "三月", "四月", "五月", "六月", "七月", "八月", "九月", "十月", "十一月", "十二月"];
-
-const viewYear = ref<number>(2026);
-const viewMonth = ref<number>(0); // Jan
-const selectedDate = ref<Date | null>(null);
-const selectedTime = ref<string | null>(null);
-
-const yearOptions = computed(() => [2025, 2026, 2027, 2028]);
-const timeOptions = [
-  { time: "09:00", remain: 3 },
-  { time: "10:00", remain: 5 },
-  { time: "11:00", remain: 2 },
-  { time: "13:00", remain: 4 },
-  { time: "14:00", remain: 1 },
-  { time: "15:00", remain: 6 },
-];
-
-const contactName = ref<string>("");
-const contactPhone = ref<string>("");
-const contactEmail = ref<string>("");
-const contactNote = ref<string>("");
-
-const isContactValid = computed(() => {
-  return !!contactName.value.trim() && !!contactPhone.value.trim() && !!contactEmail.value.trim();
-});
-
-const maxUnlocked = computed(() => {
-  if (step.value === 1) return selectedService.value ? 2 : 1;
-  if (step.value === 2) return selectedVehicle.value ? 3 : 2;
-  if (step.value === 3) return selectedDate.value && selectedTime.value ? 4 : 3;
-  if (step.value === 4) return isContactValid.value ? 5 : 4;
-  return 5;
-});
-
-const goToStep = (n: number) => {
-  const target = Math.min(5, Math.max(1, n));
-  step.value = Math.min(target, maxUnlocked.value);
-};
-
-const nextStep = () => {
-  if (!canGoNext.value) return;
-  step.value = Math.min(5, step.value + 1);
-};
-
-const prevStep = () => {
-  step.value = Math.max(1, step.value - 1);
-};
-
-const canGoNext = computed(() => {
-  if (step.value === 1) return selectedService.value !== null;
-  if (step.value === 2) return selectedVehicle.value !== null;
-  if (step.value === 3) return selectedDate.value !== null && selectedTime.value !== null;
-  if (step.value === 4) return isContactValid.value;
-  return true;
-});
-
-const canFinish = computed(() => {
-  return (
-    selectedService.value !== null &&
-    selectedVehicle.value !== null &&
-    selectedDate.value !== null &&
-    selectedTime.value !== null &&
-    isContactValid.value
-  );
-});
-
-  
-const serviceCardClass = (key: ServiceKey) => {
-  return selectedService.value === key
-    ? "border-[#6B6B5C] bg-[#6B6B5C] shadow-[0_3px_0_rgba(0,0,0,0.18)]"
-    : "border-[#E6E6DF] bg-white hover:border-[#CFCFC6]";
-};
-const vehicleCardClass = (key: VehicleKey) => {
-  return selectedVehicle.value === key
-    ? "border-[#6B6B5C] bg-[#FAFAF8]"
-    : "border-[#E6E6DF] bg-white hover:border-[#CFCFC6]";
-};
-
-const prevBtnClass = computed(() => {
-  return step.value === 1
-    ? "border-[#E6E6DF] text-[#B5B5AD] bg-[#FBFAF7] cursor-not-allowed"
-    : "border-[#E6E6DF] text-[#6B6B5C] bg-[#FBFAF7] hover:bg-white";
-});
-const nextBtnClass = computed(() => {
-  return canGoNext.value
-    ? "bg-[#6B6B5C] hover:opacity-95 active:opacity-90 shadow-[0_3px_0_rgba(0,0,0,0.18)]"
-    : "bg-[#D1D1CB] cursor-not-allowed";
-});
-
-const toMonIndex = (jsDay: number) => (jsDay + 6) % 7;
-
-const calendarCellsMon42 = computed(() => {
-  const first = new Date(viewYear.value, viewMonth.value, 1);
-  const firstMonIdx = toMonIndex(first.getDay());
-  const start = new Date(viewYear.value, viewMonth.value, 1 - firstMonIdx);
-
-  const cells: Array<{ key: string; date: Date; inMonth: boolean }> = [];
-  for (let i = 0; i < 42; i++) {
-    const d = new Date(start);
-    d.setDate(start.getDate() + i);
-    cells.push({
-      key: `${d.getFullYear()}-${d.getMonth()}-${d.getDate()}`,
-      date: d,
-      inMonth: d.getMonth() === viewMonth.value,
-    });
-  }
-  return cells;
-});
-
-const sameDay = (a: Date, b: Date) =>
-  a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth() && a.getDate() === b.getDate();
-
-const dayBtnClass = (d: Date, inMonth: boolean) => {
-  const sel = selectedDate.value && sameDay(d, selectedDate.value);
-  if (sel) return "bg-[#6B6B5C] text-white";
-  if (!inMonth) return "text-[#D1D1CB] hover:bg-transparent";
-  return "text-[#2B2B2B] hover:bg-[#F5F4EF]";
-};
-
-const onPickDate = (d: Date) => {
-  selectedDate.value = new Date(d);
-};
-
-const prevMonth = () => {
-  if (viewMonth.value === 0) {
-    viewMonth.value = 11;
-    viewYear.value -= 1;
-  } else {
-    viewMonth.value -= 1;
-  }
-};
-const nextMonth = () => {
-  if (viewMonth.value === 11) {
-    viewMonth.value = 0;
-    viewYear.value += 1;
-  } else {
-    viewMonth.value += 1;
-  }
-};
-
-const weekdayCN = ["星期日", "星期一", "星期二", "星期三", "星期四", "星期五", "星期六"];
-const pad2 = (n: number) => String(n).padStart(2, "0");
-
-const selectedDateLong = computed(() => {
-  if (!selectedDate.value) return "";
-  const y = selectedDate.value.getFullYear();
-  const m = pad2(selectedDate.value.getMonth() + 1);
-  const d = pad2(selectedDate.value.getDate());
-  const w = weekdayCN[selectedDate.value.getDay()];
-  return `${y}年 ${m}月 ${d}日 ${w}`;
-});
-
-const selectedTimeLong = computed(() => {
-  if (!selectedTime.value) return "";
-  const hour = Number(selectedTime.value.split(":")[0] || 0);
-  const period = hour < 12 ? "早上" : hour < 18 ? "下午" : "晚上";
-  return `${selectedTime.value} ${period}`;
-});
-
-const timeRowClass = (t: string) => {
-  const active = selectedTime.value === t;
-  return active ? "border-transparent bg-[#6B6B5C]" : "border-[#E6E6DF] bg-white hover:border-[#CFCFC6]";
-};
-
-const selectedServiceObj = computed(() => serviceOptions.find((s) => s.key === selectedService.value) || null);
-const selectedVehicleObj = computed(() => vehicleOptions.find((v) => v.key === selectedVehicle.value) || null);
-
-const showSuccess = ref(false);
-const bookingCode = ref<string>("");
-
-const randomBookingCode = () => {
-  const n = Math.floor(10000000 + Math.random() * 90000000);
-  return `BK${n}`;
-};
-
-const finish = () => {
-  if (!canFinish.value) return;
-  bookingCode.value = randomBookingCode();
-  showSuccess.value = true;
-};
-
-const resetAll = () => {
-  showSuccess.value = false;
-
-  step.value = 1;
-  selectedService.value = null;
-  selectedVehicle.value = null;
-  selectedDate.value = null;
-  selectedTime.value = null;
-
-  contactName.value = "";
-  contactPhone.value = "";
-  contactEmail.value = "";
-  contactNote.value = "";
-};
-</script>

--- a/src/components/service-search/ServiceSearchFlow.vue
+++ b/src/components/service-search/ServiceSearchFlow.vue
@@ -1,40 +1,239 @@
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import BookingStepper from "./ServiceStepper.vue";
+import BookingSuccessModal from "./ServiceModal.vue";
+
+/** Steps */
+type StepKey = "service" | "vehicle" | "datetime" | "contact" | "confirm";
+const steps: Array<{ key: StepKey; label: string }> = [
+  { key: "service", label: "選擇服務" },
+  { key: "vehicle", label: "車輛類型" },
+  { key: "datetime", label: "日期時段" },
+  { key: "contact", label: "聯絡資訊" },
+  { key: "confirm", label: "確認預約" },
+];
+
+const step = ref<number>(1);
+
+type ServiceKey = "oil" | "tire" | "brake" | "maintain";
+const serviceOptions: Array<{ key: ServiceKey; title: string; minutes: number; fa: string }> = [
+  { key: "oil", title: "機油更換", minutes: 30, fa: "fa-solid fa-oil-can" },
+  { key: "tire", title: "輪胎檢修", minutes: 45, fa: "fa-solid fa-car-side" },
+  { key: "brake", title: "煞車系統檢查", minutes: 60, fa: "fa-solid fa-circle-check" },
+  { key: "maintain", title: "定期保養", minutes: 90, fa: "fa-solid fa-screwdriver-wrench" },
+];
+const selectedService = ref<ServiceKey | null>(null);
+
+type VehicleKey = "sedan" | "suv" | "truck" | "motor";
+const vehicleOptions: Array<{ key: VehicleKey; title: string; subtitle: string }> = [
+  { key: "sedan", title: "轎車", subtitle: "一般房車" },
+  { key: "suv", title: "SUV/休旅車", subtitle: "運動休旅車" },
+  { key: "truck", title: "貨車", subtitle: "小型貨車" },
+  { key: "motor", title: "機車", subtitle: "機車類" },
+];
+const selectedVehicle = ref<VehicleKey | null>(null);
+
+const weekDaysMon = ["一", "二", "三", "四", "五", "六", "日"];
+const monthOptions = ["一月", "二月", "三月", "四月", "五月", "六月", "七月", "八月", "九月", "十月", "十一月", "十二月"];
+
+const viewYear = ref<number>(2026);
+const viewMonth = ref<number>(0); // Jan
+const selectedDate = ref<Date | null>(null);
+const selectedTime = ref<string | null>(null);
+
+const yearOptions = computed(() => [2025, 2026, 2027, 2028]);
+const timeOptions = [
+  { time: "09:00", remain: 3 },
+  { time: "10:00", remain: 5 },
+  { time: "11:00", remain: 2 },
+  { time: "13:00", remain: 4 },
+  { time: "14:00", remain: 1 },
+  { time: "15:00", remain: 6 },
+];
+
+const contactName = ref<string>("");
+const contactPhone = ref<string>("");
+const contactEmail = ref<string>("");
+
+const isContactValid = computed(() => {
+  return !!contactName.value.trim() && !!contactPhone.value.trim() && !!contactEmail.value.trim();
+});
+
+const maxUnlocked = computed(() => {
+  if (step.value === 1) return selectedService.value ? 2 : 1;
+  if (step.value === 2) return selectedVehicle.value ? 3 : 2;
+  if (step.value === 3) return selectedDate.value && selectedTime.value ? 4 : 3;
+  if (step.value === 4) return isContactValid.value ? 5 : 4;
+  return 5;
+});
+
+const goToStep = (n: number) => {
+  const target = Math.min(5, Math.max(1, n));
+  step.value = Math.min(target, maxUnlocked.value);
+};
+
+const nextStep = () => {
+  if (!canGoNext.value) return;
+  step.value = Math.min(5, step.value + 1);
+};
+
+const prevStep = () => {
+  step.value = Math.max(1, step.value - 1);
+};
+
+const canGoNext = computed(() => {
+  if (step.value === 1) return selectedService.value !== null;
+  if (step.value === 2) return selectedVehicle.value !== null;
+  if (step.value === 3) return selectedDate.value !== null && selectedTime.value !== null;
+  if (step.value === 4) return isContactValid.value;
+  return true;
+});
+
+const canFinish = computed(() => {
+  return (
+    selectedService.value !== null &&
+    selectedVehicle.value !== null &&
+    selectedDate.value !== null &&
+    selectedTime.value !== null &&
+    isContactValid.value
+  );
+});
+
+  
+const serviceCardClass = (key: ServiceKey) => {
+  return selectedService.value === key ? "border-[#6E6E6A]" : "border-[#E6E6DF] hover:border-[#CFCFC6]";
+};
+const vehicleCardClass = (key: VehicleKey) => {
+  return selectedVehicle.value === key
+    ? "border-[#6E6E6A] bg-[#FAFAF8]"
+    : "border-[#E6E6DF] bg-white hover:border-[#CFCFC6]";
+};
+
+const prevBtnClass = computed(() => {
+  return step.value === 1
+    ? "border-[#E6E6DF] text-[#B5B5AD] bg-[#FBFAF7] cursor-not-allowed"
+    : "border-[#E6E6DF] text-[#6E6E6A] bg-[#FBFAF7] hover:bg-white";
+});
+const nextBtnClass = computed(() => {
+  return canGoNext.value
+    ? "bg-[#6E6E6A] hover:opacity-95 active:opacity-90 shadow-[0_3px_0_rgba(0,0,0,0.18)]"
+    : "bg-[#D1D1CB] cursor-not-allowed";
+});
+
+const toMonIndex = (jsDay: number) => (jsDay + 6) % 7;
+
+const calendarCellsMon42 = computed(() => {
+  const first = new Date(viewYear.value, viewMonth.value, 1);
+  const firstMonIdx = toMonIndex(first.getDay());
+  const start = new Date(viewYear.value, viewMonth.value, 1 - firstMonIdx);
+
+  const cells: Array<{ key: string; date: Date; inMonth: boolean }> = [];
+  for (let i = 0; i < 42; i++) {
+    const d = new Date(start);
+    d.setDate(start.getDate() + i);
+    cells.push({
+      key: `${d.getFullYear()}-${d.getMonth()}-${d.getDate()}`,
+      date: d,
+      inMonth: d.getMonth() === viewMonth.value,
+    });
+  }
+  return cells;
+});
+
+const sameDay = (a: Date, b: Date) =>
+  a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth() && a.getDate() === b.getDate();
+
+const dayBtnClass = (d: Date, inMonth: boolean) => {
+  const sel = selectedDate.value && sameDay(d, selectedDate.value);
+  if (sel) return "bg-[#6E6E6A] text-white";
+  if (!inMonth) return "text-[#D1D1CB] hover:bg-transparent";
+  return "text-[#2B2B2B] hover:bg-[#F5F4EF]";
+};
+
+const onPickDate = (d: Date) => {
+  selectedDate.value = new Date(d);
+};
+
+const prevMonth = () => {
+  if (viewMonth.value === 0) {
+    viewMonth.value = 11;
+    viewYear.value -= 1;
+  } else {
+    viewMonth.value -= 1;
+  }
+};
+const nextMonth = () => {
+  if (viewMonth.value === 11) {
+    viewMonth.value = 0;
+    viewYear.value += 1;
+  } else {
+    viewMonth.value += 1;
+  }
+};
+
+const weekdayCN = ["星期日", "星期一", "星期二", "星期三", "星期四", "星期五", "星期六"];
+const pad2 = (n: number) => String(n).padStart(2, "0");
+
+const selectedDateLong = computed(() => {
+  if (!selectedDate.value) return "";
+  const y = selectedDate.value.getFullYear();
+  const m = pad2(selectedDate.value.getMonth() + 1);
+  const d = pad2(selectedDate.value.getDate());
+  const w = weekdayCN[selectedDate.value.getDay()];
+  return `${y}年 ${m}月 ${d}日 ${w}`;
+});
+
+const selectedTimeLong = computed(() => {
+  if (!selectedTime.value) return "";
+  const hour = Number(selectedTime.value.split(":")[0] || 0);
+  const period = hour < 12 ? "早上" : hour < 18 ? "下午" : "晚上";
+  return `${selectedTime.value} ${period}`;
+});
+
+const timeRowClass = (t: string) => {
+  const active = selectedTime.value === t;
+  return active ? "border-transparent bg-[#6E6E6A]" : "border-[#E6E6DF] bg-white hover:border-[#CFCFC6]";
+};
+
+const selectedServiceObj = computed(() => serviceOptions.find((s) => s.key === selectedService.value) || null);
+const selectedVehicleObj = computed(() => vehicleOptions.find((v) => v.key === selectedVehicle.value) || null);
+
+const showSuccess = ref(false);
+const bookingCode = ref<string>("");
+
+const randomBookingCode = () => {
+  const n = Math.floor(10000000 + Math.random() * 90000000);
+  return `BK${n}`;
+};
+
+const finish = () => {
+  if (!canFinish.value) return;
+  bookingCode.value = randomBookingCode();
+  showSuccess.value = true;
+};
+
+const resetAll = () => {
+  showSuccess.value = false;
+
+  step.value = 1;
+  selectedService.value = null;
+  selectedVehicle.value = null;
+  selectedDate.value = null;
+  selectedTime.value = null;
+
+  contactName.value = "";
+  contactPhone.value = "";
+  contactEmail.value = "";
+};
+</script>
+
 <template>
   <div class="min-h-screen bg-[#FAF8F5] px-6 py-10 text-[#2B2B2B]">
     <div class="mx-auto w-full max-w-6xl rounded-[28px] border border-[#E6E6DF] bg-white shadow-[0_2px_10px_rgba(0,0,0,0.06)]">
       <div class="p-10">
-        <div class="relative">
-          <div class="absolute left-0 right-0 top-[18px] h-px bg-[#E6E6DF]" />
-          <div
-            v-if="step > 1"
-            class="absolute left-0 top-[18px] h-px bg-[#6E6E6A]"
-            :style="{ width: progressWidth }"
-          />
-          <div class="grid grid-cols-5 items-start gap-0">
-            <button
-              v-for="(s, idx) in steps"
-              :key="s.key"
-              type="button"
-              class="group relative flex flex-col items-center gap-3"
-              @click="goToStep(idx + 1)"
-            >
-              <span
-                class="grid h-9 w-9 place-items-center rounded-full text-sm font-semibold transition"
-                :class="circleClass(idx + 1)"
-              >
-                <template v-if="idx + 1 < step">
-                  <i class="fa-solid fa-check text-[14px]" aria-hidden="true"></i>
-                </template>
-                <template v-else>
-                  {{ idx + 1 }}
-                </template>
-              </span>
-              <span class="text-sm transition" :class="labelClass(idx + 1)">
-                {{ s.label }}
-              </span>
-            </button>
-          </div>
-        </div>
-        <div class="mt-16">
+                <BookingStepper :step="step" :steps="steps" @go="goToStep" />
+
+<div class="mt-16">
           <div v-if="step === 1">
             <h2 class="text-3xl font-bold tracking-tight">選擇服務項目</h2>
             <div class="mt-10 grid grid-cols-2 gap-6">
@@ -337,285 +536,6 @@
         </div>
       </div>
     </div>
-    <div v-if="showSuccess" class="fixed inset-0 z-50 bg-black/40">
-      <div class="absolute inset-0 flex items-center justify-center p-6">
-        <div
-          class="relative w-full max-w-[680px] rounded-2xl border border-[#E6E6DF] bg-[#FBFAF7] shadow-[0_20px_60px_rgba(0,0,0,0.25)]"
-        >
-          <button
-            type="button"
-            class="absolute right-5 top-5 text-[#6E6E6A] hover:opacity-80"
-            aria-label="close"
-            @click="showSuccess = false"
-          >
-            <i class="fa-solid fa-xmark text-xl" aria-hidden="true"></i>
-          </button>
-          <div class="px-10 pb-10 pt-12 text-center">
-            <div class="mx-auto grid h-20 w-20 place-items-center rounded-full bg-[#F2F1EC] text-[#6E6E6A]">
-              <i class="fa-regular fa-circle-check text-4xl" aria-hidden="true"></i>
-            </div>
-            <div class="mt-6 text-3xl font-extrabold">預約成功！</div>
-            <div class="mt-3 text-lg font-semibold text-[#7A7A7A]">您的預約已送出</div>
-            <div class="mx-auto mt-8 w-full max-w-[260px] rounded-2xl border border-[#E6E6DF] bg-[#F6F5F0] px-6 py-5">
-              <div class="text-sm font-semibold text-[#7A7A7A]">預約編號</div>
-              <div class="mt-2 text-lg font-extrabold tracking-wide text-[#2B2B2B]">
-                {{ bookingCode }}
-              </div>
-            </div>
-            <div class="mt-8 text-sm leading-7 text-[#7A7A7A]">
-              我們已發送確認信至您的電子郵件，請留意相關通知。
-            </div>
-            <button
-              type="button"
-              class="mt-8 w-full rounded-xl bg-[#6E6E6A] px-6 py-4 text-base font-bold text-white hover:opacity-95 active:opacity-90"
-              @click="resetAll"
-            >
-              再次預約
-            </button>
-          </div>
-        </div>
-      </div>
-    </div>
+        <BookingSuccessModal v-if="showSuccess" :bookingCode="bookingCode" @close="showSuccess = false" @again="resetAll" />
   </div>
 </template>
-
-<script setup lang="ts">
-import { computed, ref } from "vue";
-
-/** Steps */
-type StepKey = "service" | "vehicle" | "datetime" | "contact" | "confirm";
-const steps: Array<{ key: StepKey; label: string }> = [
-  { key: "service", label: "選擇服務" },
-  { key: "vehicle", label: "車輛類型" },
-  { key: "datetime", label: "日期時段" },
-  { key: "contact", label: "聯絡資訊" },
-  { key: "confirm", label: "確認預約" },
-];
-
-const step = ref<number>(1);
-
-type ServiceKey = "oil" | "tire" | "brake" | "maintain";
-const serviceOptions: Array<{ key: ServiceKey; title: string; minutes: number; fa: string }> = [
-  { key: "oil", title: "機油更換", minutes: 30, fa: "fa-solid fa-oil-can" },
-  { key: "tire", title: "輪胎檢修", minutes: 45, fa: "fa-solid fa-car-side" },
-  { key: "brake", title: "煞車系統檢查", minutes: 60, fa: "fa-solid fa-circle-check" },
-  { key: "maintain", title: "定期保養", minutes: 90, fa: "fa-solid fa-screwdriver-wrench" },
-];
-const selectedService = ref<ServiceKey | null>(null);
-
-type VehicleKey = "sedan" | "suv" | "truck" | "motor";
-const vehicleOptions: Array<{ key: VehicleKey; title: string; subtitle: string }> = [
-  { key: "sedan", title: "轎車", subtitle: "一般房車" },
-  { key: "suv", title: "SUV/休旅車", subtitle: "運動休旅車" },
-  { key: "truck", title: "貨車", subtitle: "小型貨車" },
-  { key: "motor", title: "機車", subtitle: "機車類" },
-];
-const selectedVehicle = ref<VehicleKey | null>(null);
-
-const weekDaysMon = ["一", "二", "三", "四", "五", "六", "日"];
-const monthOptions = ["一月", "二月", "三月", "四月", "五月", "六月", "七月", "八月", "九月", "十月", "十一月", "十二月"];
-
-const viewYear = ref<number>(2026);
-const viewMonth = ref<number>(0); // Jan
-const selectedDate = ref<Date | null>(null);
-const selectedTime = ref<string | null>(null);
-
-const yearOptions = computed(() => [2025, 2026, 2027, 2028]);
-const timeOptions = [
-  { time: "09:00", remain: 3 },
-  { time: "10:00", remain: 5 },
-  { time: "11:00", remain: 2 },
-  { time: "13:00", remain: 4 },
-  { time: "14:00", remain: 1 },
-  { time: "15:00", remain: 6 },
-];
-
-const contactName = ref<string>("");
-const contactPhone = ref<string>("");
-const contactEmail = ref<string>("");
-
-const isContactValid = computed(() => {
-  return !!contactName.value.trim() && !!contactPhone.value.trim() && !!contactEmail.value.trim();
-});
-
-const maxUnlocked = computed(() => {
-  if (step.value === 1) return selectedService.value ? 2 : 1;
-  if (step.value === 2) return selectedVehicle.value ? 3 : 2;
-  if (step.value === 3) return selectedDate.value && selectedTime.value ? 4 : 3;
-  if (step.value === 4) return isContactValid.value ? 5 : 4;
-  return 5;
-});
-
-const goToStep = (n: number) => {
-  const target = Math.min(5, Math.max(1, n));
-  step.value = Math.min(target, maxUnlocked.value);
-};
-
-const nextStep = () => {
-  if (!canGoNext.value) return;
-  step.value = Math.min(5, step.value + 1);
-};
-
-const prevStep = () => {
-  step.value = Math.max(1, step.value - 1);
-};
-
-const canGoNext = computed(() => {
-  if (step.value === 1) return selectedService.value !== null;
-  if (step.value === 2) return selectedVehicle.value !== null;
-  if (step.value === 3) return selectedDate.value !== null && selectedTime.value !== null;
-  if (step.value === 4) return isContactValid.value;
-  return true;
-});
-
-const canFinish = computed(() => {
-  return (
-    selectedService.value !== null &&
-    selectedVehicle.value !== null &&
-    selectedDate.value !== null &&
-    selectedTime.value !== null &&
-    isContactValid.value
-  );
-});
-
-const progressWidth = computed(() => {
-  const segments = steps.length - 1;
-  const done = Math.max(0, step.value - 1);
-  return `${(done / segments) * 100}%`;
-});
-
-const circleClass = (n: number) => {
-  if (n <= step.value) return "bg-[#6E6E6A] text-white";
-  return "bg-white text-[#7A7A7A] border border-[#E6E6DF]";
-};
-const labelClass = (n: number) => {
-  if (n === step.value) return "text-[#2B2B2B] font-semibold";
-  return "text-[#7A7A7A]";
-};
-
-const serviceCardClass = (key: ServiceKey) => {
-  return selectedService.value === key ? "border-[#6E6E6A]" : "border-[#E6E6DF] hover:border-[#CFCFC6]";
-};
-const vehicleCardClass = (key: VehicleKey) => {
-  return selectedVehicle.value === key
-    ? "border-[#6E6E6A] bg-[#FAFAF8]"
-    : "border-[#E6E6DF] bg-white hover:border-[#CFCFC6]";
-};
-
-const prevBtnClass = computed(() => {
-  return step.value === 1
-    ? "border-[#E6E6DF] text-[#B5B5AD] bg-[#FBFAF7] cursor-not-allowed"
-    : "border-[#E6E6DF] text-[#6E6E6A] bg-[#FBFAF7] hover:bg-white";
-});
-const nextBtnClass = computed(() => {
-  return canGoNext.value
-    ? "bg-[#6E6E6A] hover:opacity-95 active:opacity-90 shadow-[0_3px_0_rgba(0,0,0,0.18)]"
-    : "bg-[#D1D1CB] cursor-not-allowed";
-});
-
-const toMonIndex = (jsDay: number) => (jsDay + 6) % 7;
-
-const calendarCellsMon42 = computed(() => {
-  const first = new Date(viewYear.value, viewMonth.value, 1);
-  const firstMonIdx = toMonIndex(first.getDay());
-  const start = new Date(viewYear.value, viewMonth.value, 1 - firstMonIdx);
-
-  const cells: Array<{ key: string; date: Date; inMonth: boolean }> = [];
-  for (let i = 0; i < 42; i++) {
-    const d = new Date(start);
-    d.setDate(start.getDate() + i);
-    cells.push({
-      key: `${d.getFullYear()}-${d.getMonth()}-${d.getDate()}`,
-      date: d,
-      inMonth: d.getMonth() === viewMonth.value,
-    });
-  }
-  return cells;
-});
-
-const sameDay = (a: Date, b: Date) =>
-  a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth() && a.getDate() === b.getDate();
-
-const dayBtnClass = (d: Date, inMonth: boolean) => {
-  const sel = selectedDate.value && sameDay(d, selectedDate.value);
-  if (sel) return "bg-[#6E6E6A] text-white";
-  if (!inMonth) return "text-[#D1D1CB] hover:bg-transparent";
-  return "text-[#2B2B2B] hover:bg-[#F5F4EF]";
-};
-
-const onPickDate = (d: Date) => {
-  selectedDate.value = new Date(d);
-};
-
-const prevMonth = () => {
-  if (viewMonth.value === 0) {
-    viewMonth.value = 11;
-    viewYear.value -= 1;
-  } else {
-    viewMonth.value -= 1;
-  }
-};
-const nextMonth = () => {
-  if (viewMonth.value === 11) {
-    viewMonth.value = 0;
-    viewYear.value += 1;
-  } else {
-    viewMonth.value += 1;
-  }
-};
-
-const weekdayCN = ["星期日", "星期一", "星期二", "星期三", "星期四", "星期五", "星期六"];
-const pad2 = (n: number) => String(n).padStart(2, "0");
-
-const selectedDateLong = computed(() => {
-  if (!selectedDate.value) return "";
-  const y = selectedDate.value.getFullYear();
-  const m = pad2(selectedDate.value.getMonth() + 1);
-  const d = pad2(selectedDate.value.getDate());
-  const w = weekdayCN[selectedDate.value.getDay()];
-  return `${y}年 ${m}月 ${d}日 ${w}`;
-});
-
-const selectedTimeLong = computed(() => {
-  if (!selectedTime.value) return "";
-  const hour = Number(selectedTime.value.split(":")[0] || 0);
-  const period = hour < 12 ? "早上" : hour < 18 ? "下午" : "晚上";
-  return `${selectedTime.value} ${period}`;
-});
-
-const timeRowClass = (t: string) => {
-  const active = selectedTime.value === t;
-  return active ? "border-transparent bg-[#6E6E6A]" : "border-[#E6E6DF] bg-white hover:border-[#CFCFC6]";
-};
-
-const selectedServiceObj = computed(() => serviceOptions.find((s) => s.key === selectedService.value) || null);
-const selectedVehicleObj = computed(() => vehicleOptions.find((v) => v.key === selectedVehicle.value) || null);
-
-const showSuccess = ref(false);
-const bookingCode = ref<string>("");
-
-const randomBookingCode = () => {
-  const n = Math.floor(10000000 + Math.random() * 90000000);
-  return `BK${n}`;
-};
-
-const finish = () => {
-  if (!canFinish.value) return;
-  bookingCode.value = randomBookingCode();
-  showSuccess.value = true;
-};
-
-const resetAll = () => {
-  showSuccess.value = false;
-
-  step.value = 1;
-  selectedService.value = null;
-  selectedVehicle.value = null;
-  selectedDate.value = null;
-  selectedTime.value = null;
-
-  contactName.value = "";
-  contactPhone.value = "";
-  contactEmail.value = "";
-};
-</script>

--- a/src/components/service-search/ServiceSearchFlow.vue
+++ b/src/components/service-search/ServiceSearchFlow.vue
@@ -2,7 +2,7 @@
 import { computed, ref } from "vue";
 import ServiceStepper from "./ServiceStepper.vue";
 import ServiceModal from "./ServiceModal.vue";
-import BookingTimeSelectorView from "../BookingTimeSelectorView.vue"; //引入Booking元件
+import BookingTimeSelectorView from "../BookingTimeSelectorView.vue";
 
 defineEmits<{
   (e: "back"): void;
@@ -26,15 +26,12 @@ const serviceOptions: Array<{ key: ServiceKey; title: string; minutes: number; f
   { key: "maintain", title: "定期保養", minutes: 90, fa: "fa-solid fa-screwdriver-wrench" },
 ];
 const selectedService = ref<ServiceKey | null>(null);
-
 const selectedDate = ref<Date | null>(null);
 const selectedTime = ref<string | null>(null);
-
 const contactName = ref<string>("");
 const contactPhone = ref<string>("");
 const contactEmail = ref<string>("");
 const contactNote = ref<string>("");
-
 const isContactValid = computed(() => {
   return !!contactName.value.trim() && !!contactPhone.value.trim() && !!contactEmail.value.trim();
 });
@@ -105,11 +102,7 @@ const selectedDateLong = computed(() => {
   return `${y}年 ${m}月 ${d}日 ${w}`;
 });
 
-// 修正：因為組員的元件回傳的格式已經是 "09:00 早上"，不需要再額外處理
-const selectedTimeLong = computed(() => {
-  return selectedTime.value || "";
-});
-
+const selectedTimeLong = computed(() => selectedTime.value || "");
 const selectedServiceObj = computed(() => serviceOptions.find((s) => s.key === selectedService.value) || null);
 
 interface SummaryItem {
@@ -183,12 +176,10 @@ const finish = () => {
 
 const resetAll = () => {
   showSuccess.value = false;
-
   step.value = 1;
   selectedService.value = null;
   selectedDate.value = null;
   selectedTime.value = null;
-
   contactName.value = "";
   contactPhone.value = "";
   contactEmail.value = "";
@@ -219,7 +210,7 @@ const resetAll = () => {
                 v-for="item in serviceOptions"
                 :key="item.key"
                 type="button"
-                class="flex items-center gap-5 rounded-2xl border bg-white px-7 py-6 text-left transition"
+                class="flex items-center gap-5 rounded-2xl border px-7 py-6 text-left transition"
                 :class="serviceCardClass(item.key)"
                 @click="selectedService = item.key"
               >
@@ -240,14 +231,12 @@ const resetAll = () => {
               </button>
             </div>
           </div>
-          
           <div v-else-if="step === 2">
             <BookingTimeSelectorView 
               v-model:date="selectedDate" 
               v-model:time="selectedTime" 
             />
           </div>
-
           <div v-else-if="step === 3">
             <h2 class="text-3xl font-bold tracking-tight">聯絡資訊</h2>
             <div class="mt-10 rounded-2xl border border-[#E6E6DF] bg-white px-10 py-6">
@@ -311,7 +300,6 @@ const resetAll = () => {
               </div>
             </div>
           </div>
-          
           <div v-else>
             <h2 class="text-3xl font-bold tracking-tight">確認預約資訊</h2>
             <div class="mt-10 rounded-2xl border border-[#E6E6DF] bg-white px-10 py-2">
@@ -371,6 +359,6 @@ const resetAll = () => {
         </div>
       </div>
     </div>
-        <ServiceModal v-if="showSuccess" :bookingCode="bookingCode" @close="showSuccess = false" @again="resetAll" />
+    <ServiceModal v-if="showSuccess" :bookingCode="bookingCode" @close="showSuccess = false" @again="resetAll" />
   </div>
 </template>

--- a/src/components/service-search/ServiceSearchFlow.vue
+++ b/src/components/service-search/ServiceSearchFlow.vue
@@ -3,12 +3,10 @@ import { computed, ref } from "vue";
 import ServiceStepper from "./ServiceStepper.vue";
 import ServiceModal from "./ServiceModal.vue";
 
-// 定義 emit，讓父層可以監聽 'back' 事件來處理返回邏輯
 defineEmits<{
   (e: "back"): void;
 }>();
 
-/** Steps - 維持 4 步驟 (已移除 vehicle) */
 type StepKey = "service" | "datetime" | "contact" | "confirm";
 const steps: Array<{ key: StepKey; label: string }> = [
   { key: "service", label: "選擇服務" },
@@ -55,7 +53,6 @@ const isContactValid = computed(() => {
   return !!contactName.value.trim() && !!contactPhone.value.trim() && !!contactEmail.value.trim();
 });
 
-// 邏輯調整：總共 4 步
 const maxUnlocked = computed(() => {
   if (step.value === 1) return selectedService.value ? 2 : 1;
   if (step.value === 2) return selectedDate.value && selectedTime.value ? 3 : 2;
@@ -218,7 +215,6 @@ const resetAll = () => {
 
 <template>
   <div class="min-h-screen bg-[#FAF8F5] px-6 py-10 text-[#2B2B2B]">
-    
     <div class="mx-auto mb-6 w-full max-w-6xl">
       <button
         type="button"
@@ -226,14 +222,12 @@ const resetAll = () => {
         @click="$emit('back')"
       >
         <i class="fa-solid fa-arrow-left"></i>
-        返回店家介紹頁面
+        返回維修廠介紹頁面
       </button>
     </div>
-
     <div class="mx-auto w-full max-w-6xl rounded-[28px] border border-[#E6E6DF] bg-white shadow-[0_2px_10px_rgba(0,0,0,0.06)]">
       <div class="p-10">
         <ServiceStepper :step="step" :steps="steps" @go="goToStep" />
-
         <div class="mt-16">
           <div v-if="step === 1">
             <h2 class="text-3xl font-bold tracking-tight">選擇服務項目</h2>
@@ -263,7 +257,6 @@ const resetAll = () => {
               </button>
             </div>
           </div>
-          
           <div v-else-if="step === 2">
             <h2 class="text-3xl font-bold tracking-tight">選擇日期</h2>
             <div class="mt-10 grid grid-cols-2 gap-8">
@@ -374,7 +367,6 @@ const resetAll = () => {
               </div>
             </div>
           </div>
-
           <div v-else-if="step === 3">
             <h2 class="text-3xl font-bold tracking-tight">聯絡資訊</h2>
             <div class="mt-10 rounded-2xl border border-[#E6E6DF] bg-white px-10 py-6">
@@ -421,9 +413,7 @@ const resetAll = () => {
                   />
                 </div>
               </div>
-
               <div class="h-px bg-[#E6E6DF]" />
-
               <div class="grid grid-cols-[44px_1fr] gap-6 py-7">
                 <div class="pt-1 text-[#6E6E6A]">
                   <i class="fa-regular fa-pen-to-square text-2xl" aria-hidden="true"></i>
@@ -440,7 +430,6 @@ const resetAll = () => {
               </div>
             </div>
           </div>
-
           <div v-else>
             <h2 class="text-3xl font-bold tracking-tight">確認預約資訊</h2>
             <div class="mt-10 rounded-2xl border border-[#E6E6DF] bg-white px-10 py-2">
@@ -495,9 +484,7 @@ const resetAll = () => {
                   <div class="mt-2 text-lg font-semibold">{{ contactEmail || "—" }}</div>
                 </div>
               </div>
-
               <div class="h-px bg-[#E6E6DF]" />
-
               <div class="grid grid-cols-[44px_1fr] gap-6 py-8">
                 <div class="pt-1 text-[#6E6E6A]">
                   <i class="fa-regular fa-pen-to-square text-2xl" aria-hidden="true"></i>

--- a/src/components/service-search/ServiceSearchFlow.vue
+++ b/src/components/service-search/ServiceSearchFlow.vue
@@ -32,6 +32,7 @@ const contactName = ref<string>("");
 const contactPhone = ref<string>("");
 const contactEmail = ref<string>("");
 const contactNote = ref<string>("");
+
 const isContactValid = computed(() => {
   return !!contactName.value.trim() && !!contactPhone.value.trim() && !!contactEmail.value.trim();
 });
@@ -90,16 +91,14 @@ const nextBtnClass = computed(() => {
     : "bg-[#D1D1CB] cursor-not-allowed";
 });
 
-const weekdayCN = ["星期日", "星期一", "星期二", "星期三", "星期四", "星期五", "星期六"];
-const pad2 = (n: number) => String(n).padStart(2, "0");
-
 const selectedDateLong = computed(() => {
   if (!selectedDate.value) return "";
-  const y = selectedDate.value.getFullYear();
-  const m = pad2(selectedDate.value.getMonth() + 1);
-  const d = pad2(selectedDate.value.getDate());
-  const w = weekdayCN[selectedDate.value.getDay()];
-  return `${y}年 ${m}月 ${d}日 ${w}`;
+  return selectedDate.value.toLocaleDateString("zh-TW", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    weekday: "long",
+  });
 });
 
 const selectedTimeLong = computed(() => selectedTime.value || "");

--- a/src/components/service-search/ServiceSearchFlow.vue
+++ b/src/components/service-search/ServiceSearchFlow.vue
@@ -2,6 +2,7 @@
 import { computed, ref } from "vue";
 import ServiceStepper from "./ServiceStepper.vue";
 import ServiceModal from "./ServiceModal.vue";
+import BookingTimeSelectorView from "../BookingTimeSelectorView.vue"; //引入Booking元件
 
 defineEmits<{
   (e: "back"): void;
@@ -26,23 +27,8 @@ const serviceOptions: Array<{ key: ServiceKey; title: string; minutes: number; f
 ];
 const selectedService = ref<ServiceKey | null>(null);
 
-const weekDaysMon = ["一", "二", "三", "四", "五", "六", "日"];
-const monthOptions = ["一月", "二月", "三月", "四月", "五月", "六月", "七月", "八月", "九月", "十月", "十一月", "十二月"];
-
-const viewYear = ref<number>(2026);
-const viewMonth = ref<number>(0); // Jan
 const selectedDate = ref<Date | null>(null);
 const selectedTime = ref<string | null>(null);
-
-const yearOptions = computed(() => [2026, 2027, 2028]);
-const timeOptions = [
-  { time: "09:00", remain: 3 },
-  { time: "10:00", remain: 5 },
-  { time: "11:00", remain: 2 },
-  { time: "13:00", remain: 4 },
-  { time: "14:00", remain: 1 },
-  { time: "15:00", remain: 6 },
-];
 
 const contactName = ref<string>("");
 const contactPhone = ref<string>("");
@@ -107,57 +93,6 @@ const nextBtnClass = computed(() => {
     : "bg-[#D1D1CB] cursor-not-allowed";
 });
 
-const toMonIndex = (jsDay: number) => (jsDay + 6) % 7;
-
-const calendarCellsMon42 = computed(() => {
-  const first = new Date(viewYear.value, viewMonth.value, 1);
-  const firstMonIdx = toMonIndex(first.getDay());
-  const start = new Date(viewYear.value, viewMonth.value, 1 - firstMonIdx);
-
-  const cells: Array<{ key: string; date: Date; inMonth: boolean }> = [];
-  for (let i = 0; i < 42; i++) {
-    const d = new Date(start);
-    d.setDate(start.getDate() + i);
-    cells.push({
-      key: `${d.getFullYear()}-${d.getMonth()}-${d.getDate()}`,
-      date: d,
-      inMonth: d.getMonth() === viewMonth.value,
-    });
-  }
-  return cells;
-});
-
-const sameDay = (a: Date, b: Date) =>
-  a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth() && a.getDate() === b.getDate();
-
-const dayBtnClass = (d: Date, inMonth: boolean) => {
-  const sel = selectedDate.value && sameDay(d, selectedDate.value);
-  if (sel) return "bg-[#6B6B5C] text-white";
-  if (!inMonth) return "text-[#D1D1CB] hover:bg-transparent";
-  return "text-[#2B2B2B] hover:bg-[#F5F4EF]";
-};
-
-const onPickDate = (d: Date) => {
-  selectedDate.value = new Date(d);
-};
-
-const prevMonth = () => {
-  if (viewMonth.value === 0) {
-    viewMonth.value = 11;
-    viewYear.value -= 1;
-  } else {
-    viewMonth.value -= 1;
-  }
-};
-const nextMonth = () => {
-  if (viewMonth.value === 11) {
-    viewMonth.value = 0;
-    viewYear.value += 1;
-  } else {
-    viewMonth.value += 1;
-  }
-};
-
 const weekdayCN = ["星期日", "星期一", "星期二", "星期三", "星期四", "星期五", "星期六"];
 const pad2 = (n: number) => String(n).padStart(2, "0");
 
@@ -170,19 +105,67 @@ const selectedDateLong = computed(() => {
   return `${y}年 ${m}月 ${d}日 ${w}`;
 });
 
+// 修正：因為組員的元件回傳的格式已經是 "09:00 早上"，不需要再額外處理
 const selectedTimeLong = computed(() => {
-  if (!selectedTime.value) return "";
-  const hour = Number(selectedTime.value.split(":")[0] || 0);
-  const period = hour < 12 ? "早上" : hour < 18 ? "下午" : "晚上";
-  return `${selectedTime.value} ${period}`;
+  return selectedTime.value || "";
 });
 
-const timeRowClass = (t: string) => {
-  const active = selectedTime.value === t;
-  return active ? "border-transparent bg-[#6B6B5C]" : "border-[#E6E6DF] bg-white hover:border-[#CFCFC6]";
-};
-
 const selectedServiceObj = computed(() => serviceOptions.find((s) => s.key === selectedService.value) || null);
+
+interface SummaryItem {
+  key: string;
+  icon: string;
+  iconClass?: string;
+  label: string;
+  value: string;
+  valueClass?: string;
+  details?: string;
+  detailsClass?: string;
+}
+
+const summaryItems = computed<SummaryItem[]>(() => [
+  {
+    key: "service",
+    icon: "fa-solid fa-wrench",
+    label: "服務項目",
+    value: selectedServiceObj.value?.title || "—",
+    details: `預估時間：${selectedServiceObj.value?.minutes ?? "—"}分鐘`,
+  },
+  {
+    key: "datetime",
+    icon: "fa-regular fa-calendar",
+    label: "預約日期 & 時段",
+    value: selectedDateLong.value || "—",
+    details: selectedTimeLong.value || "—",
+    detailsClass: "text-lg font-semibold text-[#7A7A7A]",
+  },
+  {
+    key: "name",
+    icon: "fa-regular fa-user",
+    label: "姓名",
+    value: contactName.value || "—",
+  },
+  {
+    key: "phone",
+    icon: "fa-solid fa-phone",
+    label: "電話",
+    value: contactPhone.value || "—",
+  },
+  {
+    key: "email",
+    icon: "fa-regular fa-envelope",
+    label: "電子郵件",
+    value: contactEmail.value || "—",
+  },
+  {
+    key: "note",
+    icon: "fa-regular fa-pen-to-square",
+    iconClass: "text-[#6E6E6A]",
+    label: "備註",
+    value: contactNote.value || "—",
+    valueClass: "whitespace-pre-wrap",
+  },
+]);
 
 const showSuccess = ref(false);
 const bookingCode = ref<string>("");
@@ -236,7 +219,7 @@ const resetAll = () => {
                 v-for="item in serviceOptions"
                 :key="item.key"
                 type="button"
-                class="flex items-center gap-5 rounded-2xl border px-7 py-6 text-left transition"
+                class="flex items-center gap-5 rounded-2xl border bg-white px-7 py-6 text-left transition"
                 :class="serviceCardClass(item.key)"
                 @click="selectedService = item.key"
               >
@@ -257,116 +240,14 @@ const resetAll = () => {
               </button>
             </div>
           </div>
+          
           <div v-else-if="step === 2">
-            <h2 class="text-3xl font-bold tracking-tight">選擇日期</h2>
-            <div class="mt-10 grid grid-cols-2 gap-8">
-              <div class="rounded-2xl border border-[#E6E6DF] bg-white p-8">
-                <div class="flex items-center justify-center gap-4">
-                  <button
-                    type="button"
-                    class="grid h-10 w-10 place-items-center rounded-xl bg-[#F5F4EF] text-lg text-[#6B6B5C] hover:opacity-90"
-                    @click="prevMonth"
-                    aria-label="prev month"
-                  >
-                    <i class="fa-solid fa-chevron-left text-sm" aria-hidden="true"></i>
-                  </button>
-                  <div class="flex items-center gap-3">
-                    <div class="relative">
-                      <select
-                        v-model.number="viewYear"
-                        class="h-10 appearance-none rounded-xl bg-[#F5F4EF] px-4 pr-10 text-sm font-semibold text-[#2B2B2B] outline-none"
-                      >
-                        <option v-for="y in yearOptions" :key="y" :value="y">{{ y }}年</option>
-                      </select>
-                      <span class="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-[#7A7A7A]"
-                        >▾</span
-                      >
-                    </div>
-                    <div class="relative">
-                      <select
-                        v-model.number="viewMonth"
-                        class="h-10 appearance-none rounded-xl bg-[#F5F4EF] px-4 pr-10 text-sm font-semibold text-[#2B2B2B] outline-none"
-                      >
-                        <option v-for="(m, idx) in monthOptions" :key="m" :value="idx">{{ m }}</option>
-                      </select>
-                      <span class="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-[#7A7A7A]"
-                        >▾</span
-                      >
-                    </div>
-                  </div>
-                  <button
-                    type="button"
-                    class="grid h-10 w-10 place-items-center rounded-xl bg-[#F5F4EF] text-lg text-[#6B6B5C] hover:opacity-90"
-                    @click="nextMonth"
-                    aria-label="next month"
-                  >
-                    <i class="fa-solid fa-chevron-right text-sm" aria-hidden="true"></i>
-                  </button>
-                </div>
-                <div class="mt-10 grid grid-cols-7 gap-4 text-center text-sm font-semibold text-[#6B6B5C]">
-                  <div v-for="d in weekDaysMon" :key="d">{{ d }}</div>
-                </div>
-                <div class="mt-6 grid grid-cols-7 gap-4 text-center">
-                  <button
-                    v-for="cell in calendarCellsMon42"
-                    :key="cell.key"
-                    type="button"
-                    class="h-11 w-11 rounded-xl text-base font-semibold transition"
-                    :class="dayBtnClass(cell.date, cell.inMonth)"
-                    @click="onPickDate(cell.date)"
-                  >
-                    {{ cell.date.getDate() }}
-                  </button>
-                </div>
-              </div>
-              <div class="space-y-6">
-                <div class="rounded-2xl border border-[#E6E6DF] bg-white px-6 py-5">
-                  <div class="flex items-start gap-4">
-                    <div class="mt-0.5 text-[#6B6B5C]">
-                      <i class="fa-regular fa-calendar text-xl" aria-hidden="true"></i>
-                    </div>
-                    <div class="min-w-0">
-                      <div class="text-lg font-bold">{{ selectedDateLong || "尚未選擇日期" }}</div>
-                      <div class="mt-2 text-lg font-semibold text-[#7A7A7A]">
-                        {{ selectedTimeLong || "請選擇時段" }}
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <div class="text-sm font-semibold text-[#6B6B5C]">選擇時段</div>
-                <div class="rounded-2xl border border-[#E6E6DF] bg-white p-4">
-                  <div class="max-h-[320px] overflow-y-auto pr-2">
-                    <button
-                      v-for="t in timeOptions"
-                      :key="t.time"
-                      type="button"
-                      class="mb-3 flex w-full items-center justify-between rounded-2xl border px-5 py-4 text-left transition"
-                      :class="timeRowClass(t.time)"
-                      @click="selectedTime = t.time"
-                    >
-                      <div class="flex items-center gap-3">
-                        <span :class="selectedTime === t.time ? 'text-white' : 'text-[#6B6B5C]'" class="shrink-0">
-                          <i class="fa-regular fa-clock text-lg" aria-hidden="true"></i>
-                        </span>
-                        <div
-                          class="text-base font-bold"
-                          :class="selectedTime === t.time ? 'text-white' : 'text-[#2B2B2B]'"
-                        >
-                          {{ t.time }}
-                        </div>
-                      </div>
-                      <div
-                        class="text-sm font-semibold"
-                        :class="selectedTime === t.time ? 'text-white/90' : 'text-[#7A7A7A]'"
-                      >
-                        剩餘 {{ t.remain }}
-                      </div>
-                    </button>
-                  </div>
-                </div>
-              </div>
-            </div>
+            <BookingTimeSelectorView 
+              v-model:date="selectedDate" 
+              v-model:time="selectedTime" 
+            />
           </div>
+
           <div v-else-if="step === 3">
             <h2 class="text-3xl font-bold tracking-tight">聯絡資訊</h2>
             <div class="mt-10 rounded-2xl border border-[#E6E6DF] bg-white px-10 py-6">
@@ -430,69 +311,30 @@ const resetAll = () => {
               </div>
             </div>
           </div>
+          
           <div v-else>
             <h2 class="text-3xl font-bold tracking-tight">確認預約資訊</h2>
             <div class="mt-10 rounded-2xl border border-[#E6E6DF] bg-white px-10 py-2">
-              <div class="grid grid-cols-[44px_1fr] gap-6 py-8">
-                <div class="pt-1 text-[#6B6B5C]">
-                  <i class="fa-solid fa-wrench text-2xl" aria-hidden="true"></i>
+              <div v-for="(item, index) in summaryItems" :key="item.key">
+                <div class="grid grid-cols-[44px_1fr] gap-6 py-8">
+                  <div class="pt-1" :class="item.iconClass || 'text-[#6B6B5C]'">
+                    <i :class="[item.icon, 'text-2xl']" aria-hidden="true"></i>
+                  </div>
+                  <div>
+                    <div class="text-base font-semibold text-[#6B6B5C]">{{ item.label }}</div>
+                    <div class="mt-2 text-lg font-semibold" :class="item.valueClass">
+                      {{ item.value }}
+                    </div>
+                    <div 
+                      v-if="item.details" 
+                      class="mt-2"
+                      :class="item.detailsClass || 'text-sm text-[#7A7A7A]'"
+                    >
+                      {{ item.details }}
+                    </div>
+                  </div>
                 </div>
-                <div>
-                  <div class="text-base font-semibold text-[#6B6B5C]">服務項目</div>
-                  <div class="mt-2 text-lg font-semibold">{{ selectedServiceObj?.title || "—" }}</div>
-                  <div class="mt-2 text-sm text-[#7A7A7A]">預估時間：{{ selectedServiceObj?.minutes ?? "—" }}分鐘</div>
-                </div>
-              </div>
-              <div class="h-px bg-[#E6E6DF]" />
-              <div class="grid grid-cols-[44px_1fr] gap-6 py-8">
-                <div class="pt-1 text-[#6B6B5C]">
-                  <i class="fa-regular fa-calendar text-2xl" aria-hidden="true"></i>
-                </div>
-                <div>
-                  <div class="text-base font-semibold text-[#6B6B5C]">預約日期 &amp; 時段</div>
-                  <div class="mt-2 text-lg font-semibold">{{ selectedDateLong || "—" }}</div>
-                  <div class="mt-2 text-lg font-semibold text-[#7A7A7A]">{{ selectedTimeLong || "—" }}</div>
-                </div>
-              </div>
-              <div class="h-px bg-[#E6E6DF]" />
-              <div class="grid grid-cols-[44px_1fr] gap-6 py-8">
-                <div class="pt-1 text-[#6B6B5C]">
-                  <i class="fa-regular fa-user text-2xl" aria-hidden="true"></i>
-                </div>
-                <div>
-                  <div class="text-base font-semibold text-[#6B6B5C]">姓名</div>
-                  <div class="mt-2 text-lg font-semibold">{{ contactName || "—" }}</div>
-                </div>
-              </div>
-              <div class="h-px bg-[#E6E6DF]" />
-              <div class="grid grid-cols-[44px_1fr] gap-6 py-8">
-                <div class="pt-1 text-[#6B6B5C]">
-                  <i class="fa-solid fa-phone text-2xl" aria-hidden="true"></i>
-                </div>
-                <div>
-                  <div class="text-base font-semibold text-[#6B6B5C]">電話</div>
-                  <div class="mt-2 text-lg font-semibold">{{ contactPhone || "—" }}</div>
-                </div>
-              </div>
-              <div class="h-px bg-[#E6E6DF]" />
-              <div class="grid grid-cols-[44px_1fr] gap-6 py-8">
-                <div class="pt-1 text-[#6B6B5C]">
-                  <i class="fa-regular fa-envelope text-2xl" aria-hidden="true"></i>
-                </div>
-                <div>
-                  <div class="text-base font-semibold text-[#6B6B5C]">電子郵件</div>
-                  <div class="mt-2 text-lg font-semibold">{{ contactEmail || "—" }}</div>
-                </div>
-              </div>
-              <div class="h-px bg-[#E6E6DF]" />
-              <div class="grid grid-cols-[44px_1fr] gap-6 py-8">
-                <div class="pt-1 text-[#6E6E6A]">
-                  <i class="fa-regular fa-pen-to-square text-2xl" aria-hidden="true"></i>
-                </div>
-                <div>
-                  <div class="text-base font-semibold text-[#6B6B5C]">備註</div>
-                  <div class="mt-2 whitespace-pre-wrap text-lg font-semibold">{{ contactNote || "—" }}</div>
-                </div>
+                <div v-if="index < summaryItems.length - 1" class="h-px bg-[#E6E6DF]" />
               </div>
             </div>
           </div>

--- a/src/components/service-search/ServiceSearchFlow.vue
+++ b/src/components/service-search/ServiceSearchFlow.vue
@@ -1,7 +1,356 @@
+<template>
+  <div class="min-h-screen bg-[#FAF8F5] px-6 py-10 text-[#2B2B2B]">
+    <div class="mx-auto w-full max-w-6xl rounded-[28px] border border-[#E6E6DF] bg-white shadow-[0_2px_10px_rgba(0,0,0,0.06)]">
+      <div class="p-10">
+        <ServiceStepper :step="step" :steps="steps" @go="goToStep" />
+
+        <div class="mt-16">
+          <div v-if="step === 1">
+            <h2 class="text-3xl font-bold tracking-tight">選擇服務項目</h2>
+            <div class="mt-10 grid grid-cols-2 gap-6">
+              <button
+                v-for="item in serviceOptions"
+                :key="item.key"
+                type="button"
+                class="flex items-center gap-5 rounded-2xl border px-7 py-6 text-left transition"
+                :class="serviceCardClass(item.key)"
+                @click="selectedService = item.key"
+              >
+                <div 
+                  class="grid h-14 w-14 place-items-center rounded-2xl transition"
+                  :class="selectedService === item.key ? 'bg-white/20 text-white' : 'bg-[#F5F4EF] text-[#6B6B5C]'"
+                >
+                  <i :class="item.fa" class="text-xl" aria-hidden="true"></i>
+                </div>
+                <div class="min-w-0">
+                  <div 
+                    class="text-lg font-semibold transition"
+                    :class="selectedService === item.key ? 'text-white' : 'text-[#2B2B2B]'"
+                  >
+                    {{ item.title }}
+                  </div>
+                  </div>
+              </button>
+            </div>
+          </div>
+          <div v-else-if="step === 2">
+            <h2 class="text-3xl font-bold tracking-tight">選擇車輛類型</h2>
+            <div class="mt-10 grid grid-cols-2 gap-6">
+              <button
+                v-for="v in vehicleOptions"
+                :key="v.key"
+                type="button"
+                class="flex items-center gap-6 rounded-2xl border px-8 py-7 text-left transition"
+                :class="vehicleCardClass(v.key)"
+                @click="selectedVehicle = v.key"
+              >
+                <span
+                  class="relative grid h-5 w-5 place-items-center rounded-full border"
+                  :class="selectedVehicle === v.key ? 'border-[#6B6B5C]' : 'border-[#E6E6DF]'"
+                >
+                  <span v-if="selectedVehicle === v.key" class="h-2.5 w-2.5 rounded-full bg-[#6B6B5C]" />
+                </span>
+                <div>
+                  <div class="text-lg font-semibold">{{ v.title }}</div>
+                  <div class="mt-1 text-sm text-[#7A7A7A]">{{ v.subtitle }}</div>
+                </div>
+              </button>
+            </div>
+          </div>
+          <div v-else-if="step === 3">
+            <h2 class="text-3xl font-bold tracking-tight">選擇日期</h2>
+            <div class="mt-10 grid grid-cols-2 gap-8">
+              <div class="rounded-2xl border border-[#E6E6DF] bg-white p-8">
+                <div class="flex items-center justify-center gap-4">
+                  <button
+                    type="button"
+                    class="grid h-10 w-10 place-items-center rounded-xl bg-[#F5F4EF] text-lg text-[#6B6B5C] hover:opacity-90"
+                    @click="prevMonth"
+                    aria-label="prev month"
+                  >
+                    <i class="fa-solid fa-chevron-left text-sm" aria-hidden="true"></i>
+                  </button>
+                  <div class="flex items-center gap-3">
+                    <div class="relative">
+                      <select
+                        v-model.number="viewYear"
+                        class="h-10 appearance-none rounded-xl bg-[#F5F4EF] px-4 pr-10 text-sm font-semibold text-[#2B2B2B] outline-none"
+                      >
+                        <option v-for="y in yearOptions" :key="y" :value="y">{{ y }}年</option>
+                      </select>
+                      <span class="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-[#7A7A7A]"
+                        >▾</span
+                      >
+                    </div>
+                    <div class="relative">
+                      <select
+                        v-model.number="viewMonth"
+                        class="h-10 appearance-none rounded-xl bg-[#F5F4EF] px-4 pr-10 text-sm font-semibold text-[#2B2B2B] outline-none"
+                      >
+                        <option v-for="(m, idx) in monthOptions" :key="m" :value="idx">{{ m }}</option>
+                      </select>
+                      <span class="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-[#7A7A7A]"
+                        >▾</span
+                      >
+                    </div>
+                  </div>
+                  <button
+                    type="button"
+                    class="grid h-10 w-10 place-items-center rounded-xl bg-[#F5F4EF] text-lg text-[#6B6B5C] hover:opacity-90"
+                    @click="nextMonth"
+                    aria-label="next month"
+                  >
+                    <i class="fa-solid fa-chevron-right text-sm" aria-hidden="true"></i>
+                  </button>
+                </div>
+                <div class="mt-10 grid grid-cols-7 gap-4 text-center text-sm font-semibold text-[#6B6B5C]">
+                  <div v-for="d in weekDaysMon" :key="d">{{ d }}</div>
+                </div>
+                <div class="mt-6 grid grid-cols-7 gap-4 text-center">
+                  <button
+                    v-for="cell in calendarCellsMon42"
+                    :key="cell.key"
+                    type="button"
+                    class="h-11 w-11 rounded-xl text-base font-semibold transition"
+                    :class="dayBtnClass(cell.date, cell.inMonth)"
+                    @click="onPickDate(cell.date)"
+                  >
+                    {{ cell.date.getDate() }}
+                  </button>
+                </div>
+              </div>
+              <div class="space-y-6">
+                <div class="rounded-2xl border border-[#E6E6DF] bg-white px-6 py-5">
+                  <div class="flex items-start gap-4">
+                    <div class="mt-0.5 text-[#6B6B5C]">
+                      <i class="fa-regular fa-calendar text-xl" aria-hidden="true"></i>
+                    </div>
+                    <div class="min-w-0">
+                      <div class="text-lg font-bold">{{ selectedDateLong || "尚未選擇日期" }}</div>
+                      <div class="mt-2 text-lg font-semibold text-[#7A7A7A]">
+                        {{ selectedTimeLong || "請選擇時段" }}
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div class="text-sm font-semibold text-[#6B6B5C]">選擇時段</div>
+                <div class="rounded-2xl border border-[#E6E6DF] bg-white p-4">
+                  <div class="max-h-[320px] overflow-y-auto pr-2">
+                    <button
+                      v-for="t in timeOptions"
+                      :key="t.time"
+                      type="button"
+                      class="mb-3 flex w-full items-center justify-between rounded-2xl border px-5 py-4 text-left transition"
+                      :class="timeRowClass(t.time)"
+                      @click="selectedTime = t.time"
+                    >
+                      <div class="flex items-center gap-3">
+                        <span :class="selectedTime === t.time ? 'text-white' : 'text-[#6B6B5C]'" class="shrink-0">
+                          <i class="fa-regular fa-clock text-lg" aria-hidden="true"></i>
+                        </span>
+                        <div
+                          class="text-base font-bold"
+                          :class="selectedTime === t.time ? 'text-white' : 'text-[#2B2B2B]'"
+                        >
+                          {{ t.time }}
+                        </div>
+                      </div>
+                      <div
+                        class="text-sm font-semibold"
+                        :class="selectedTime === t.time ? 'text-white/90' : 'text-[#7A7A7A]'"
+                      >
+                        剩餘 {{ t.remain }}
+                      </div>
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div v-else-if="step === 4">
+            <h2 class="text-3xl font-bold tracking-tight">聯絡資訊</h2>
+            <div class="mt-10 rounded-2xl border border-[#E6E6DF] bg-white px-10 py-6">
+              <div class="grid grid-cols-[44px_1fr] gap-6 py-7">
+                <div class="pt-1 text-[#6B6B5C]">
+                  <i class="fa-regular fa-user text-2xl" aria-hidden="true"></i>
+                </div>
+                <div>
+                  <div class="text-base font-semibold text-[#6B6B5C]">姓名</div>
+                  <input
+                    v-model.trim="contactName"
+                    class="mt-3 h-11 w-full rounded-xl bg-[#F5F4EF] px-4 text-sm outline-none placeholder:text-[#B5B5AD]"
+                    placeholder="請輸入姓名"
+                  />
+                </div>
+              </div>
+              <div class="h-px bg-[#E6E6DF]" />
+              <div class="grid grid-cols-[44px_1fr] gap-6 py-7">
+                <div class="pt-1 text-[#6B6B5C]">
+                  <i class="fa-solid fa-phone text-2xl" aria-hidden="true"></i>
+                </div>
+                <div>
+                  <div class="text-base font-semibold text-[#6B6B5C]">電話</div>
+                  <input
+                    v-model.trim="contactPhone"
+                    inputmode="tel"
+                    class="mt-3 h-11 w-full rounded-xl bg-[#F5F4EF] px-4 text-sm outline-none placeholder:text-[#B5B5AD]"
+                    placeholder="請輸入電話"
+                  />
+                </div>
+              </div>
+              <div class="h-px bg-[#E6E6DF]" />
+              <div class="grid grid-cols-[44px_1fr] gap-6 py-7">
+                <div class="pt-1 text-[#6B6B5C]">
+                  <i class="fa-regular fa-envelope text-2xl" aria-hidden="true"></i>
+                </div>
+                <div>
+                  <div class="text-base font-semibold text-[#6B6B5C]">電子郵件</div>
+                  <input
+                    v-model.trim="contactEmail"
+                    inputmode="email"
+                    class="mt-3 h-11 w-full rounded-xl bg-[#F5F4EF] px-4 text-sm outline-none placeholder:text-[#B5B5AD]"
+                    placeholder="請輸入電子郵件"
+                  />
+                </div>
+              </div>
+
+              <div class="h-px bg-[#E6E6DF]" />
+
+              <div class="grid grid-cols-[44px_1fr] gap-6 py-7">
+                <div class="pt-1 text-[#6E6E6A]">
+                  <i class="fa-regular fa-pen-to-square text-2xl" aria-hidden="true"></i>
+                </div>
+                <div>
+                  <div class="text-base font-semibold text-[#6B6B5C]">備註</div>
+                  <textarea
+                    v-model.trim="contactNote"
+                    rows="3"
+                    class="mt-3 w-full resize-none rounded-xl bg-[#F5F4EF] px-4 py-3 text-sm outline-none placeholder:text-[#B5B5AD]"
+                    placeholder="如有特殊需求請在此填寫"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+          <div v-else>
+            <h2 class="text-3xl font-bold tracking-tight">確認預約資訊</h2>
+            <div class="mt-10 rounded-2xl border border-[#E6E6DF] bg-white px-10 py-2">
+              <div class="grid grid-cols-[44px_1fr] gap-6 py-8">
+                <div class="pt-1 text-[#6B6B5C]">
+                  <i class="fa-solid fa-wrench text-2xl" aria-hidden="true"></i>
+                </div>
+                <div>
+                  <div class="text-base font-semibold text-[#6B6B5C]">服務項目</div>
+                  <div class="mt-2 text-lg font-semibold">{{ selectedServiceObj?.title || "—" }}</div>
+                  <div class="mt-2 text-sm text-[#7A7A7A]">預估時間：{{ selectedServiceObj?.minutes ?? "—" }}分鐘</div>
+                </div>
+              </div>
+              <div class="h-px bg-[#E6E6DF]" />
+              <div class="grid grid-cols-[44px_1fr] gap-6 py-8">
+                <div class="pt-1 text-[#6B6B5C]">
+                  <i class="fa-solid fa-car text-2xl" aria-hidden="true"></i>
+                </div>
+                <div>
+                  <div class="text-base font-semibold text-[#6B6B5C]">車輛類型</div>
+                  <div class="mt-2 text-lg font-semibold">{{ selectedVehicleObj?.title || "—" }}</div>
+                </div>
+              </div>
+              <div class="h-px bg-[#E6E6DF]" />
+              <div class="grid grid-cols-[44px_1fr] gap-6 py-8">
+                <div class="pt-1 text-[#6B6B5C]">
+                  <i class="fa-regular fa-calendar text-2xl" aria-hidden="true"></i>
+                </div>
+                <div>
+                  <div class="text-base font-semibold text-[#6B6B5C]">預約日期 &amp; 時段</div>
+                  <div class="mt-2 text-lg font-semibold">{{ selectedDateLong || "—" }}</div>
+                  <div class="mt-2 text-lg font-semibold text-[#7A7A7A]">{{ selectedTimeLong || "—" }}</div>
+                </div>
+              </div>
+              <div class="h-px bg-[#E6E6DF]" />
+              <div class="grid grid-cols-[44px_1fr] gap-6 py-8">
+                <div class="pt-1 text-[#6B6B5C]">
+                  <i class="fa-regular fa-user text-2xl" aria-hidden="true"></i>
+                </div>
+                <div>
+                  <div class="text-base font-semibold text-[#6B6B5C]">姓名</div>
+                  <div class="mt-2 text-lg font-semibold">{{ contactName || "—" }}</div>
+                </div>
+              </div>
+              <div class="h-px bg-[#E6E6DF]" />
+              <div class="grid grid-cols-[44px_1fr] gap-6 py-8">
+                <div class="pt-1 text-[#6B6B5C]">
+                  <i class="fa-solid fa-phone text-2xl" aria-hidden="true"></i>
+                </div>
+                <div>
+                  <div class="text-base font-semibold text-[#6B6B5C]">電話</div>
+                  <div class="mt-2 text-lg font-semibold">{{ contactPhone || "—" }}</div>
+                </div>
+              </div>
+              <div class="h-px bg-[#E6E6DF]" />
+              <div class="grid grid-cols-[44px_1fr] gap-6 py-8">
+                <div class="pt-1 text-[#6B6B5C]">
+                  <i class="fa-regular fa-envelope text-2xl" aria-hidden="true"></i>
+                </div>
+                <div>
+                  <div class="text-base font-semibold text-[#6B6B5C]">電子郵件</div>
+                  <div class="mt-2 text-lg font-semibold">{{ contactEmail || "—" }}</div>
+                </div>
+              </div>
+
+              <div class="h-px bg-[#E6E6DF]" />
+
+              <div class="grid grid-cols-[44px_1fr] gap-6 py-8">
+                <div class="pt-1 text-[#6E6E6A]">
+                  <i class="fa-regular fa-pen-to-square text-2xl" aria-hidden="true"></i>
+                </div>
+                <div>
+                  <div class="text-base font-semibold text-[#6B6B5C]">備註</div>
+                  <div class="mt-2 whitespace-pre-wrap text-lg font-semibold">{{ contactNote || "—" }}</div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="mt-14 flex items-center justify-between">
+          <button
+            type="button"
+            class="rounded-xl border px-10 py-3 text-sm font-semibold transition"
+            :class="prevBtnClass"
+            :disabled="step === 1"
+            @click="prevStep"
+          >
+            上一步
+          </button>
+          <button
+            v-if="step < 5"
+            type="button"
+            class="rounded-xl px-10 py-3 text-sm font-semibold text-white transition"
+            :class="nextBtnClass"
+            :disabled="!canGoNext"
+            @click="nextStep"
+          >
+            下一步
+          </button>
+          <button
+            v-else
+            type="button"
+            class="rounded-xl bg-[#6B6B5C] px-10 py-3 text-sm font-semibold text-white shadow-[0_3px_0_rgba(0,0,0,0.18)] hover:opacity-95 active:opacity-90"
+            :disabled="!canFinish"
+            @click="finish"
+          >
+            完成預約
+          </button>
+        </div>
+      </div>
+    </div>
+        <ServiceModal v-if="showSuccess" :bookingCode="bookingCode" @close="showSuccess = false" @again="resetAll" />
+  </div>
+</template>
+
 <script setup lang="ts">
 import { computed, ref } from "vue";
-import BookingStepper from "./ServiceStepper.vue";
-import BookingSuccessModal from "./ServiceModal.vue";
+import ServiceStepper from "./ServiceStepper.vue";
+import ServiceModal from "./ServiceModal.vue";
 
 /** Steps */
 type StepKey = "service" | "vehicle" | "datetime" | "contact" | "confirm";
@@ -54,6 +403,7 @@ const timeOptions = [
 const contactName = ref<string>("");
 const contactPhone = ref<string>("");
 const contactEmail = ref<string>("");
+const contactNote = ref<string>("");
 
 const isContactValid = computed(() => {
   return !!contactName.value.trim() && !!contactPhone.value.trim() && !!contactEmail.value.trim();
@@ -101,22 +451,24 @@ const canFinish = computed(() => {
 
   
 const serviceCardClass = (key: ServiceKey) => {
-  return selectedService.value === key ? "border-[#6E6E6A]" : "border-[#E6E6DF] hover:border-[#CFCFC6]";
+  return selectedService.value === key
+    ? "border-[#6B6B5C] bg-[#6B6B5C] shadow-[0_3px_0_rgba(0,0,0,0.18)]"
+    : "border-[#E6E6DF] bg-white hover:border-[#CFCFC6]";
 };
 const vehicleCardClass = (key: VehicleKey) => {
   return selectedVehicle.value === key
-    ? "border-[#6E6E6A] bg-[#FAFAF8]"
+    ? "border-[#6B6B5C] bg-[#FAFAF8]"
     : "border-[#E6E6DF] bg-white hover:border-[#CFCFC6]";
 };
 
 const prevBtnClass = computed(() => {
   return step.value === 1
     ? "border-[#E6E6DF] text-[#B5B5AD] bg-[#FBFAF7] cursor-not-allowed"
-    : "border-[#E6E6DF] text-[#6E6E6A] bg-[#FBFAF7] hover:bg-white";
+    : "border-[#E6E6DF] text-[#6B6B5C] bg-[#FBFAF7] hover:bg-white";
 });
 const nextBtnClass = computed(() => {
   return canGoNext.value
-    ? "bg-[#6E6E6A] hover:opacity-95 active:opacity-90 shadow-[0_3px_0_rgba(0,0,0,0.18)]"
+    ? "bg-[#6B6B5C] hover:opacity-95 active:opacity-90 shadow-[0_3px_0_rgba(0,0,0,0.18)]"
     : "bg-[#D1D1CB] cursor-not-allowed";
 });
 
@@ -145,7 +497,7 @@ const sameDay = (a: Date, b: Date) =>
 
 const dayBtnClass = (d: Date, inMonth: boolean) => {
   const sel = selectedDate.value && sameDay(d, selectedDate.value);
-  if (sel) return "bg-[#6E6E6A] text-white";
+  if (sel) return "bg-[#6B6B5C] text-white";
   if (!inMonth) return "text-[#D1D1CB] hover:bg-transparent";
   return "text-[#2B2B2B] hover:bg-[#F5F4EF]";
 };
@@ -192,7 +544,7 @@ const selectedTimeLong = computed(() => {
 
 const timeRowClass = (t: string) => {
   const active = selectedTime.value === t;
-  return active ? "border-transparent bg-[#6E6E6A]" : "border-[#E6E6DF] bg-white hover:border-[#CFCFC6]";
+  return active ? "border-transparent bg-[#6B6B5C]" : "border-[#E6E6DF] bg-white hover:border-[#CFCFC6]";
 };
 
 const selectedServiceObj = computed(() => serviceOptions.find((s) => s.key === selectedService.value) || null);
@@ -224,318 +576,6 @@ const resetAll = () => {
   contactName.value = "";
   contactPhone.value = "";
   contactEmail.value = "";
+  contactNote.value = "";
 };
 </script>
-
-<template>
-  <div class="min-h-screen bg-[#FAF8F5] px-6 py-10 text-[#2B2B2B]">
-    <div class="mx-auto w-full max-w-6xl rounded-[28px] border border-[#E6E6DF] bg-white shadow-[0_2px_10px_rgba(0,0,0,0.06)]">
-      <div class="p-10">
-                <BookingStepper :step="step" :steps="steps" @go="goToStep" />
-
-<div class="mt-16">
-          <div v-if="step === 1">
-            <h2 class="text-3xl font-bold tracking-tight">選擇服務項目</h2>
-            <div class="mt-10 grid grid-cols-2 gap-6">
-              <button
-                v-for="item in serviceOptions"
-                :key="item.key"
-                type="button"
-                class="flex items-center gap-5 rounded-2xl border bg-white px-7 py-6 text-left transition"
-                :class="serviceCardClass(item.key)"
-                @click="selectedService = item.key"
-              >
-                <div class="grid h-14 w-14 place-items-center rounded-2xl bg-[#F5F4EF] text-[#6E6E6A]">
-                  <i :class="item.fa" class="text-xl" aria-hidden="true"></i>
-                </div>
-                <div class="min-w-0">
-                  <div class="text-lg font-semibold">{{ item.title }}</div>
-                  <div class="mt-1 text-sm text-[#7A7A7A]">預估時間：{{ item.minutes }}分鐘</div>
-                </div>
-              </button>
-            </div>
-          </div>
-          <div v-else-if="step === 2">
-            <h2 class="text-3xl font-bold tracking-tight">選擇車輛類型</h2>
-            <div class="mt-10 grid grid-cols-2 gap-6">
-              <button
-                v-for="v in vehicleOptions"
-                :key="v.key"
-                type="button"
-                class="flex items-center gap-6 rounded-2xl border px-8 py-7 text-left transition"
-                :class="vehicleCardClass(v.key)"
-                @click="selectedVehicle = v.key"
-              >
-                <span
-                  class="relative grid h-5 w-5 place-items-center rounded-full border"
-                  :class="selectedVehicle === v.key ? 'border-[#6E6E6A]' : 'border-[#E6E6DF]'"
-                >
-                  <span v-if="selectedVehicle === v.key" class="h-2.5 w-2.5 rounded-full bg-[#6E6E6A]" />
-                </span>
-                <div>
-                  <div class="text-lg font-semibold">{{ v.title }}</div>
-                  <div class="mt-1 text-sm text-[#7A7A7A]">{{ v.subtitle }}</div>
-                </div>
-              </button>
-            </div>
-          </div>
-          <div v-else-if="step === 3">
-            <h2 class="text-3xl font-bold tracking-tight">選擇日期</h2>
-            <div class="mt-10 grid grid-cols-2 gap-8">
-              <div class="rounded-2xl border border-[#E6E6DF] bg-white p-8">
-                <div class="flex items-center justify-center gap-4">
-                  <button
-                    type="button"
-                    class="grid h-10 w-10 place-items-center rounded-xl bg-[#F5F4EF] text-lg text-[#6E6E6A] hover:opacity-90"
-                    @click="prevMonth"
-                    aria-label="prev month"
-                  >
-                    <i class="fa-solid fa-chevron-left text-sm" aria-hidden="true"></i>
-                  </button>
-                  <div class="flex items-center gap-3">
-                    <div class="relative">
-                      <select
-                        v-model.number="viewYear"
-                        class="h-10 appearance-none rounded-xl bg-[#F5F4EF] px-4 pr-10 text-sm font-semibold text-[#2B2B2B] outline-none"
-                      >
-                        <option v-for="y in yearOptions" :key="y" :value="y">{{ y }}年</option>
-                      </select>
-                      <span class="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-[#7A7A7A]"
-                        >▾</span
-                      >
-                    </div>
-                    <div class="relative">
-                      <select
-                        v-model.number="viewMonth"
-                        class="h-10 appearance-none rounded-xl bg-[#F5F4EF] px-4 pr-10 text-sm font-semibold text-[#2B2B2B] outline-none"
-                      >
-                        <option v-for="(m, idx) in monthOptions" :key="m" :value="idx">{{ m }}</option>
-                      </select>
-                      <span class="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-[#7A7A7A]"
-                        >▾</span
-                      >
-                    </div>
-                  </div>
-                  <button
-                    type="button"
-                    class="grid h-10 w-10 place-items-center rounded-xl bg-[#F5F4EF] text-lg text-[#6E6E6A] hover:opacity-90"
-                    @click="nextMonth"
-                    aria-label="next month"
-                  >
-                    <i class="fa-solid fa-chevron-right text-sm" aria-hidden="true"></i>
-                  </button>
-                </div>
-                <div class="mt-10 grid grid-cols-7 gap-4 text-center text-sm font-semibold text-[#6E6E6A]">
-                  <div v-for="d in weekDaysMon" :key="d">{{ d }}</div>
-                </div>
-                <div class="mt-6 grid grid-cols-7 gap-4 text-center">
-                  <button
-                    v-for="cell in calendarCellsMon42"
-                    :key="cell.key"
-                    type="button"
-                    class="h-11 w-11 rounded-xl text-base font-semibold transition"
-                    :class="dayBtnClass(cell.date, cell.inMonth)"
-                    @click="onPickDate(cell.date)"
-                  >
-                    {{ cell.date.getDate() }}
-                  </button>
-                </div>
-              </div>
-              <div class="space-y-6">
-                <div class="rounded-2xl border border-[#E6E6DF] bg-white px-6 py-5">
-                  <div class="flex items-start gap-4">
-                    <div class="mt-0.5 text-[#6E6E6A]">
-                      <i class="fa-regular fa-calendar text-xl" aria-hidden="true"></i>
-                    </div>
-                    <div class="min-w-0">
-                      <div class="text-lg font-bold">{{ selectedDateLong || "尚未選擇日期" }}</div>
-                      <div class="mt-2 text-lg font-semibold text-[#7A7A7A]">
-                        {{ selectedTimeLong || "請選擇時段" }}
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <div class="text-sm font-semibold text-[#6E6E6A]">選擇時段</div>
-                <div class="rounded-2xl border border-[#E6E6DF] bg-white p-4">
-                  <div class="max-h-[320px] overflow-y-auto pr-2">
-                    <button
-                      v-for="t in timeOptions"
-                      :key="t.time"
-                      type="button"
-                      class="mb-3 flex w-full items-center justify-between rounded-2xl border px-5 py-4 text-left transition"
-                      :class="timeRowClass(t.time)"
-                      @click="selectedTime = t.time"
-                    >
-                      <div class="flex items-center gap-3">
-                        <span :class="selectedTime === t.time ? 'text-white' : 'text-[#6E6E6A]'" class="shrink-0">
-                          <i class="fa-regular fa-clock text-lg" aria-hidden="true"></i>
-                        </span>
-                        <div
-                          class="text-base font-bold"
-                          :class="selectedTime === t.time ? 'text-white' : 'text-[#2B2B2B]'"
-                        >
-                          {{ t.time }}
-                        </div>
-                      </div>
-                      <div
-                        class="text-sm font-semibold"
-                        :class="selectedTime === t.time ? 'text-white/90' : 'text-[#7A7A7A]'"
-                      >
-                        剩餘 {{ t.remain }}
-                      </div>
-                    </button>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div v-else-if="step === 4">
-            <h2 class="text-3xl font-bold tracking-tight">聯絡資訊</h2>
-            <div class="mt-10 rounded-2xl border border-[#E6E6DF] bg-white px-10 py-6">
-              <div class="grid grid-cols-[44px_1fr] gap-6 py-7">
-                <div class="pt-1 text-[#6E6E6A]">
-                  <i class="fa-regular fa-user text-2xl" aria-hidden="true"></i>
-                </div>
-                <div>
-                  <div class="text-base font-semibold text-[#6E6E6A]">姓名</div>
-                  <input
-                    v-model.trim="contactName"
-                    class="mt-3 h-11 w-full rounded-xl bg-[#F5F4EF] px-4 text-sm outline-none placeholder:text-[#B5B5AD]"
-                    placeholder="請輸入姓名"
-                  />
-                </div>
-              </div>
-              <div class="h-px bg-[#E6E6DF]" />
-              <div class="grid grid-cols-[44px_1fr] gap-6 py-7">
-                <div class="pt-1 text-[#6E6E6A]">
-                  <i class="fa-solid fa-phone text-2xl" aria-hidden="true"></i>
-                </div>
-                <div>
-                  <div class="text-base font-semibold text-[#6E6E6A]">電話</div>
-                  <input
-                    v-model.trim="contactPhone"
-                    inputmode="tel"
-                    class="mt-3 h-11 w-full rounded-xl bg-[#F5F4EF] px-4 text-sm outline-none placeholder:text-[#B5B5AD]"
-                    placeholder="請輸入電話"
-                  />
-                </div>
-              </div>
-              <div class="h-px bg-[#E6E6DF]" />
-              <div class="grid grid-cols-[44px_1fr] gap-6 py-7">
-                <div class="pt-1 text-[#6E6E6A]">
-                  <i class="fa-regular fa-envelope text-2xl" aria-hidden="true"></i>
-                </div>
-                <div>
-                  <div class="text-base font-semibold text-[#6E6E6A]">電子郵件</div>
-                  <input
-                    v-model.trim="contactEmail"
-                    inputmode="email"
-                    class="mt-3 h-11 w-full rounded-xl bg-[#F5F4EF] px-4 text-sm outline-none placeholder:text-[#B5B5AD]"
-                    placeholder="請輸入電子郵件"
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-          <div v-else>
-            <h2 class="text-3xl font-bold tracking-tight">確認預約資訊</h2>
-            <div class="mt-10 rounded-2xl border border-[#E6E6DF] bg-white px-10 py-2">
-              <div class="grid grid-cols-[44px_1fr] gap-6 py-8">
-                <div class="pt-1 text-[#6E6E6A]">
-                  <i class="fa-solid fa-wrench text-2xl" aria-hidden="true"></i>
-                </div>
-                <div>
-                  <div class="text-base font-semibold text-[#6E6E6A]">服務項目</div>
-                  <div class="mt-2 text-lg font-semibold">{{ selectedServiceObj?.title || "—" }}</div>
-                  <div class="mt-2 text-sm text-[#7A7A7A]">預估時間：{{ selectedServiceObj?.minutes ?? "—" }}分鐘</div>
-                </div>
-              </div>
-              <div class="h-px bg-[#E6E6DF]" />
-              <div class="grid grid-cols-[44px_1fr] gap-6 py-8">
-                <div class="pt-1 text-[#6E6E6A]">
-                  <i class="fa-solid fa-car text-2xl" aria-hidden="true"></i>
-                </div>
-                <div>
-                  <div class="text-base font-semibold text-[#6E6E6A]">車輛類型</div>
-                  <div class="mt-2 text-lg font-semibold">{{ selectedVehicleObj?.title || "—" }}</div>
-                </div>
-              </div>
-              <div class="h-px bg-[#E6E6DF]" />
-              <div class="grid grid-cols-[44px_1fr] gap-6 py-8">
-                <div class="pt-1 text-[#6E6E6A]">
-                  <i class="fa-regular fa-calendar text-2xl" aria-hidden="true"></i>
-                </div>
-                <div>
-                  <div class="text-base font-semibold text-[#6E6E6A]">預約日期 &amp; 時段</div>
-                  <div class="mt-2 text-lg font-semibold">{{ selectedDateLong || "—" }}</div>
-                  <div class="mt-2 text-lg font-semibold text-[#7A7A7A]">{{ selectedTimeLong || "—" }}</div>
-                </div>
-              </div>
-              <div class="h-px bg-[#E6E6DF]" />
-              <div class="grid grid-cols-[44px_1fr] gap-6 py-8">
-                <div class="pt-1 text-[#6E6E6A]">
-                  <i class="fa-regular fa-user text-2xl" aria-hidden="true"></i>
-                </div>
-                <div>
-                  <div class="text-base font-semibold text-[#6E6E6A]">姓名</div>
-                  <div class="mt-2 text-lg font-semibold">{{ contactName || "—" }}</div>
-                </div>
-              </div>
-              <div class="h-px bg-[#E6E6DF]" />
-              <div class="grid grid-cols-[44px_1fr] gap-6 py-8">
-                <div class="pt-1 text-[#6E6E6A]">
-                  <i class="fa-solid fa-phone text-2xl" aria-hidden="true"></i>
-                </div>
-                <div>
-                  <div class="text-base font-semibold text-[#6E6E6A]">電話</div>
-                  <div class="mt-2 text-lg font-semibold">{{ contactPhone || "—" }}</div>
-                </div>
-              </div>
-              <div class="h-px bg-[#E6E6DF]" />
-              <div class="grid grid-cols-[44px_1fr] gap-6 py-8">
-                <div class="pt-1 text-[#6E6E6A]">
-                  <i class="fa-regular fa-envelope text-2xl" aria-hidden="true"></i>
-                </div>
-                <div>
-                  <div class="text-base font-semibold text-[#6E6E6A]">電子郵件</div>
-                  <div class="mt-2 text-lg font-semibold">{{ contactEmail || "—" }}</div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div class="mt-14 flex items-center justify-between">
-          <button
-            type="button"
-            class="rounded-xl border px-10 py-3 text-sm font-semibold transition"
-            :class="prevBtnClass"
-            :disabled="step === 1"
-            @click="prevStep"
-          >
-            上一步
-          </button>
-          <button
-            v-if="step < 5"
-            type="button"
-            class="rounded-xl px-10 py-3 text-sm font-semibold text-white transition"
-            :class="nextBtnClass"
-            :disabled="!canGoNext"
-            @click="nextStep"
-          >
-            下一步
-          </button>
-          <button
-            v-else
-            type="button"
-            class="rounded-xl bg-[#6E6E6A] px-10 py-3 text-sm font-semibold text-white shadow-[0_3px_0_rgba(0,0,0,0.18)] hover:opacity-95 active:opacity-90"
-            :disabled="!canFinish"
-            @click="finish"
-          >
-            完成預約
-          </button>
-        </div>
-      </div>
-    </div>
-        <BookingSuccessModal v-if="showSuccess" :bookingCode="bookingCode" @close="showSuccess = false" @again="resetAll" />
-  </div>
-</template>

--- a/src/components/service-search/ServiceStepper.vue
+++ b/src/components/service-search/ServiceStepper.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed } from "vue";
 
-type StepKey = "service" | "vehicle" | "datetime" | "contact" | "confirm";
+type StepKey = "service" | "datetime" | "contact" | "confirm";
 
 const props = defineProps<{
   step: number;
@@ -28,14 +28,14 @@ const labelClass = (n: number) => {
 </script>
 
 <template>
-  <div class="relative">
+  <div class="relative w-full">
     <div class="absolute left-0 right-0 top-[18px] h-px bg-[#E6E6DF]" />
     <div
       v-if="step > 1"
-      class="absolute left-0 top-[18px] h-px bg-[#6B6B5C]"
+      class="absolute left-0 top-[18px] h-px bg-[#6B6B5C] transition-all duration-300"
       :style="{ width: progressWidth }"
     />
-    <div class="grid grid-cols-5 items-start gap-0">
+    <div class="grid grid-cols-4 items-start gap-0">
       <button
         v-for="(s, idx) in steps"
         :key="s.key"
@@ -43,7 +43,10 @@ const labelClass = (n: number) => {
         class="group relative flex flex-col items-center gap-3"
         @click="$emit('go', idx + 1)"
       >
-        <span class="grid h-9 w-9 place-items-center rounded-full text-sm font-semibold transition" :class="circleClass(idx + 1)">
+        <span 
+          class="grid h-9 w-9 place-items-center rounded-full text-sm font-semibold transition z-10" 
+          :class="circleClass(idx + 1)"
+        >
           <template v-if="idx + 1 < step">
             <i class="fa-solid fa-check text-[14px]" aria-hidden="true"></i>
           </template>
@@ -51,7 +54,6 @@ const labelClass = (n: number) => {
             {{ idx + 1 }}
           </template>
         </span>
-
         <span class="text-sm transition" :class="labelClass(idx + 1)">
           {{ s.label }}
         </span>

--- a/src/components/service-search/ServiceStepper.vue
+++ b/src/components/service-search/ServiceStepper.vue
@@ -17,7 +17,7 @@ const progressWidth = computed(() => {
 });
 
 const circleClass = (n: number) => {
-  if (n <= props.step) return "bg-[#6E6E6A] text-white";
+  if (n <= props.step) return "bg-[#6B6B5C] text-white";
   return "bg-white text-[#7A7A7A] border border-[#E6E6DF]";
 };
 
@@ -32,7 +32,7 @@ const labelClass = (n: number) => {
     <div class="absolute left-0 right-0 top-[18px] h-px bg-[#E6E6DF]" />
     <div
       v-if="step > 1"
-      class="absolute left-0 top-[18px] h-px bg-[#6E6E6A]"
+      class="absolute left-0 top-[18px] h-px bg-[#6B6B5C]"
       :style="{ width: progressWidth }"
     />
     <div class="grid grid-cols-5 items-start gap-0">

--- a/src/components/service-search/ServiceStepper.vue
+++ b/src/components/service-search/ServiceStepper.vue
@@ -1,0 +1,61 @@
+<script setup lang="ts">
+import { computed } from "vue";
+
+type StepKey = "service" | "vehicle" | "datetime" | "contact" | "confirm";
+
+const props = defineProps<{
+  step: number;
+  steps: Array<{ key: StepKey; label: string }>;
+}>();
+
+defineEmits<{ (e: "go", n: number): void }>();
+
+const progressWidth = computed(() => {
+  const segments = props.steps.length - 1;
+  const done = Math.max(0, props.step - 1);
+  return `${(done / segments) * 100}%`;
+});
+
+const circleClass = (n: number) => {
+  if (n <= props.step) return "bg-[#6E6E6A] text-white";
+  return "bg-white text-[#7A7A7A] border border-[#E6E6DF]";
+};
+
+const labelClass = (n: number) => {
+  if (n === props.step) return "text-[#2B2B2B] font-semibold";
+  return "text-[#7A7A7A]";
+};
+</script>
+
+<template>
+  <div class="relative">
+    <div class="absolute left-0 right-0 top-[18px] h-px bg-[#E6E6DF]" />
+    <div
+      v-if="step > 1"
+      class="absolute left-0 top-[18px] h-px bg-[#6E6E6A]"
+      :style="{ width: progressWidth }"
+    />
+    <div class="grid grid-cols-5 items-start gap-0">
+      <button
+        v-for="(s, idx) in steps"
+        :key="s.key"
+        type="button"
+        class="group relative flex flex-col items-center gap-3"
+        @click="$emit('go', idx + 1)"
+      >
+        <span class="grid h-9 w-9 place-items-center rounded-full text-sm font-semibold transition" :class="circleClass(idx + 1)">
+          <template v-if="idx + 1 < step">
+            <i class="fa-solid fa-check text-[14px]" aria-hidden="true"></i>
+          </template>
+          <template v-else>
+            {{ idx + 1 }}
+          </template>
+        </span>
+
+        <span class="text-sm transition" :class="labelClass(idx + 1)">
+          {{ s.label }}
+        </span>
+      </button>
+    </div>
+  </div>
+</template>


### PR DESCRIPTION
### 維修廠預約流程
於App.vue裡面import顯示頁面。

這三個元件會放在一個獨立的資料夾 `service-search`，import時需要注意路徑。

`import ServiceSearchFlow from './components/service-search/ServiceSearchFlow.vue`

## 新增
1. 預約頁面的呈現
`components/service-search/ServiceSearchFlow`

2. 進度條
`components/service-search/ServiceStepper`
   > 這個Stepper可以在任意需要的元件中調用。

3. 預約成功的談窗通知
`components/service-search/ServiceModal`

## 修改
`BookingTimeSelectorView`
引入後移除了ServiceSearchFlow版面本來既有的功能，

--- 
### 目前頁面內容

- 表單填寫進度顯示
- 維修廠服務項目
- 預約日期選擇 (引入元件`BookingTimeSelectorView`)
- 預約時段選擇 & 剩餘可以接待數
- 聯絡/備註資訊填寫
- 預約成功通知
- 返回維修廠介紹頁面按鈕

<img width="1950" height="1272" alt="image" src="https://github.com/user-attachments/assets/ca041e80-c829-43a2-b3be-50d0d59d4053" />

> TODO:
我的預約查詢頁面。
預約取消功能。
串接剩餘位置的API。