### PR TITLE
#60 搜尋結果卡片、標籤元件化與重新排列至頁面

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,10 +4,14 @@
     <meta charset="UTF-8" />
     <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="stylesheet" href="main.css" rel="stylesheet" />
+    <link rel="stylesheet" href="main.css" />
     <link
-      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined"
       rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined"
+    />
+    <link 
+    rel="stylesheet" 
+    href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,1,0&icon_names=star" 
     />
 
     <title>carE 汽車維修預約平台</title>

--- a/index.html
+++ b/index.html
@@ -9,10 +9,6 @@
       rel="stylesheet"
       href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined"
     />
-    <link 
-    rel="stylesheet" 
-    href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@24,400,1,0&icon_names=star" 
-    />
 
     <title>carE 汽車維修預約平台</title>
   </head>

--- a/src/components/SearchResults.vue
+++ b/src/components/SearchResults.vue
@@ -7,11 +7,13 @@ const filterTitle = ref('篩選')
 const sortBy = ref('rating');
 
 interface ResultItem {
-  name: string
-  score: number
-  distance: number
-  brands: string[]
-  services: string[]
+  image?: string;
+  id: number;
+  name: string;
+  score: number;
+  distance: number;
+  brands: string[];
+  services: string[];
 }
 
 const results = ref<ResultItem[]>([
@@ -58,50 +60,6 @@ const resultsCount = computed(() => results.value.length)
     <div class="container mx-auto flex flex-wrap gap-5">
       <div v-if="!resultsCount">
         <p class="text-[#4a4a43]">查無相關結果</p>
-      </div>
-      <div
-        v-for="result in results"
-        class="w-full md:w-[33.3%] lg:w-[25%] border border-[#DBCEBD] rounded-[5px] overflow-hidden hover:shadow-md duration-300"
-      >
-        <img
-          src="https://picsum.photos/300/200?random=1"
-          alt="車廠環境圖片"
-          class="w-full aspect-3/2 object-cover"
-        />
-        <div class="px-5 py-3 text-[#4a4a43]">
-          <p class="my-1">{{ result.name }}</p>
-          <p class="my-1">
-            <span v-html="getStars(result.score)"></span>
-          </p>
-          <p class="flex flex-row justify-start items-center my-1">
-            <span class="material-symbols-outlined"> location_on </span>
-            {{ result.distance }} 公里
-          </p>
-          <!-- FIXME: 一行中，最左與最右標籤貼齊外容器 -->
-          <p class="flex flex-row flex-wrap justify-start items-center gap-2 my-5">
-            <span
-              v-for="brand in result.brands"
-              class="inline-block px-3 py-1 bg-[#8b7d6b] text-[14px] text-white rounded-[999px]"
-            >
-              {{ brand }}
-            </span>
-          </p>
-          <!-- FIXME: 一行中，最左與最右標籤貼齊外容器 -->
-          <p class="flex flex-row flex-wrap justify-start items-center gap-2 my-5">
-            <span
-              v-for="service in result.services"
-              class="inline-block px-3 py-1 bg-[#f5f1ed] text-[14px] text-[#8b7d6b] border border-[#8b7d6b] rounded-[999px]"
-            >
-              {{ service }}
-            </span>
-          </p>
-          <!-- TODO: click 事件 -->
-          <button
-            class="w-full block p-3 bg-[#8b7d6b] text-[14px] text-white rounded-[8px] cursor-pointer"
-          >
-            立即預約
-          </button>
-        </div>
       </div>
     </div>
   </section>

--- a/src/components/SearchResults.vue
+++ b/src/components/SearchResults.vue
@@ -76,26 +76,32 @@ onMounted(() => {
 
 <template>
   <section class="pt-10 bg-[#f5f1ed]">
-    <div class="container mx-auto">
+    <div class="container mx-auto px-4">
       <div class="flex flex-col md:flex-row justify-between items-center gap-5">
         <div class="w-full flex text-[#4a4a43] bg-[#ffffff] border border-[#DBCEBD] rounded-[5px]">
           <label for="order" class="py-2 pl-3">{{ orderTitle }}：</label>
-          <select name="order" id="order" class="grow py-2 outline-none">
-            <!-- TODO: 選項待補齊 -->
-            <option value="distance" selected>距離</option>
-            <option value="">評價</option>
-            <option value="">？？</option>
-            <option value="">？？？</option>
+          <select
+            name="order"
+            id="order"
+            class="grow py-2 outline-none"
+            @change="handleSortChange"
+            v-model="sortBy"
+            >
+            <option value="rating" selected>評價</option>
+            <option value="distance">距離</option>
+            <option value="reviewCount">評論數</option>
           </select>
         </div>
         <div class="w-full flex text-[#4a4a43] bg-[#ffffff] border border-[#DBCEBD] rounded-[5px]">
           <label for="filter" class="py-2 pl-3">{{ filterTitle }}：</label>
-          <select name="filter" id="filter" class="grow py-2 outline-none">
-            <!-- TODO: 選項待補齊 -->
+          <select
+            name="filter"
+            id="filter"
+            class="grow py-2 outline-none">
             <option value="all" selected>全部</option>
-            <option value="">？</option>
-            <option value="">？？</option>
-            <option value="">？？？</option>
+            <option value="nearby">附近</option>
+            <option value="popular">熱門</option>
+            <option value="ratingGood">評價4星以上</option>
           </select>
         </div>
       </div>

--- a/src/components/SearchResults.vue
+++ b/src/components/SearchResults.vue
@@ -107,10 +107,18 @@ onMounted(() => {
       </div>
     </div>
   </section>
-  <section class="pt-5 bg-[#f5f1ed]">
-    <div class="container mx-auto flex flex-wrap gap-5">
-      <div v-if="!resultsCount">
-        <p class="text-[#4a4a43]">查無相關結果</p>
+  <section class="pt-5 bg-[#f5f1ed] pb-10 min-h-[60vh]">
+    <div class="container mx-auto">
+      <div v-if="!resultsCount" class="text-center py-10">
+        <p class="text-[#4a4a43] text-lg">查無相關結果</p>
+      </div>
+      <div v-else class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
+        <ShopCard
+          v-for="shop in results"
+          :key="shop.id"
+          :shop="shop"
+          @view-detail="handleViewDetail"
+        />
       </div>
     </div>
   </section>

--- a/src/components/SearchResults.vue
+++ b/src/components/SearchResults.vue
@@ -5,6 +5,7 @@ import ShopCard from '@/components/ShopCard.vue'
 const orderTitle = ref('排序')
 const filterTitle = ref('篩選')
 const sortBy = ref('rating');
+const filterBy = ref('all');
 
 interface ResultItem {
   image?: string;
@@ -16,9 +17,16 @@ interface ResultItem {
   services: string[];
 }
 
-const results = ref<ResultItem[]>([])
+const allShops = ref<ResultItem[]>([])
 
-const resultsCount = computed(() => results.value.length)
+const results = computed(() => let filtered = [...allShops.value];
+  if (filterBy.value === 'nearby') {
+    filtered = filtered.filter(shop => shop.distance < 3);
+  } else if (filterBy.value === 'ratingGood') {
+    filtered = filtered.filter(shop => shop.score >= 4);
+  }
+  return filtered;
+});
 const fetchShops = async () => {
 try{
   //TODO:從API取得搜尋結果
@@ -100,7 +108,6 @@ onMounted(() => {
             class="grow py-2 outline-none">
             <option value="all" selected>全部</option>
             <option value="nearby">附近</option>
-            <option value="popular">熱門</option>
             <option value="ratingGood">評價4星以上</option>
           </select>
         </div>

--- a/src/components/SearchResults.vue
+++ b/src/components/SearchResults.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
 import { ref, computed } from 'vue'
+import ShopCard from '@/components/ShopCard.vue'
 
 const orderTitle = ref('排序')
 const filterTitle = ref('篩選')
-const starIcon = `<span class="material-symbols-outlined">kid_star</span>`
+const sortBy = ref('rating');
 
 interface ResultItem {
   name: string
@@ -22,9 +23,7 @@ const results = ref<ResultItem[]>([
     services: ['保養', '維修'],
   },
 ])
-const getStars = (score: number) => {
-  return starIcon.repeat(score)
-}
+
 const resultsCount = computed(() => results.value.length)
 </script>
 

--- a/src/components/SearchResults.vue
+++ b/src/components/SearchResults.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue'
 import ShopCard from '@/components/ShopCard.vue'
-import { log } from 'console';
 
 const orderTitle = ref('排序')
 const filterTitle = ref('篩選')
@@ -20,7 +19,10 @@ interface ResultItem {
 const results = ref<ResultItem[]>([])
 
 const resultsCount = computed(() => results.value.length)
-try{ // 範例資料，實際應從API取得
+const fetchShops = async () => {
+try{
+  //TODO:從API取得搜尋結果
+  // 範例資料，實際應從API取得
       results.value = [
       {
         id: 1,
@@ -52,9 +54,23 @@ try{ // 範例資料，實際應從API取得
     ];
 }catch(err){
   console.log('沒有符合資料的結果:', err);
+  }
+};
+// 處理排序變更
+const handleSortChange = (event: Event) => {
+  const target = event.target as HTMLSelectElement;
+  sortBy.value = target.value;
+  fetchShops();
+};
 
-}
-
+const handleViewDetail = (shopId: number) => {
+  console.log('使用者要查看商店詳細，ID:', shopId);
+  // TODO: 之後這裡會接路由跳轉
+  alert(`查看商店 ID: ${shopId} 的詳細資料`);
+};
+onMounted(() => {
+  fetchShops();
+});
 
 </script>
 

--- a/src/components/SearchResults.vue
+++ b/src/components/SearchResults.vue
@@ -19,19 +19,38 @@ interface ResultItem {
 
 const allShops = ref<ResultItem[]>([])
 
-const results = computed(() => let filtered = [...allShops.value];
+const results = computed(() => {
+  let filtered = [...allShops.value];
   if (filterBy.value === 'nearby') {
     filtered = filtered.filter(shop => shop.distance < 3);
   } else if (filterBy.value === 'ratingGood') {
     filtered = filtered.filter(shop => shop.score >= 4);
   }
+  if (filterBy.value === 'all') {
+    if (sortBy.value === 'rating') {
+      filtered.sort((a, b) => b.score - a.score);
+    } else if (sortBy.value === 'distance') {
+      filtered.sort((a, b) => a.distance - b.distance);
+    } else if (sortBy.value === 'reviewCount') {
+      filtered.sort((a, b) => b.score - a.score);
+    }
+  } else {
+    if (sortBy.value !== 'rating'){
+      if (sortBy.value === 'distance') {
+        filtered.sort((a, b) => a.distance - b.distance);
+      } else if (sortBy.value === 'reviewCount') {
+        filtered.sort((a, b) => b.score - a.score);
+      }
+    }
+  }
   return filtered;
 });
+const resultsCount = computed(() => results.value.length);
 const fetchShops = async () => {
 try{
   //TODO:從API取得搜尋結果
   // 範例資料，實際應從API取得
-      results.value = [
+      allShops.value = [
       {
         id: 1,
         name: '匠心汽車維修中心',
@@ -68,7 +87,12 @@ try{
 const handleSortChange = (event: Event) => {
   const target = event.target as HTMLSelectElement;
   sortBy.value = target.value;
-  fetchShops();
+  console.log('切換排序方式：', sortBy.value);
+};
+const handleFilterChange = (event: Event) => {
+  const target = event.target as HTMLSelectElement;
+  filterBy.value = target.value;
+  console.log('切換篩選條件：', filterBy.value);
 };
 
 const handleViewDetail = (shopId: number) => {
@@ -95,9 +119,9 @@ onMounted(() => {
             @change="handleSortChange"
             v-model="sortBy"
             >
-            <option value="rating" selected>評價</option>
-            <option value="distance">距離</option>
-            <option value="reviewCount">評論數</option>
+            <option value="rating" selected>依評價</option>
+            <option value="distance">依距離</option>
+            <option value="reviewCount">依評論數</option>
           </select>
         </div>
         <div class="w-full flex text-[#4a4a43] bg-[#ffffff] border border-[#DBCEBD] rounded-[5px]">
@@ -105,10 +129,12 @@ onMounted(() => {
           <select
             name="filter"
             id="filter"
-            class="grow py-2 outline-none">
+            class="grow py-2 outline-none"
+            @change="handleFilterChange"
+            v-model="filterBy">
             <option value="all" selected>全部</option>
-            <option value="nearby">附近</option>
-            <option value="ratingGood">評價4星以上</option>
+            <option value="nearby">附近(3公里內)</option>
+            <option value="ratingGood">評價 4 星以上</option>
           </select>
         </div>
       </div>

--- a/src/components/SearchResults.vue
+++ b/src/components/SearchResults.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
-import { ref, computed } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import ShopCard from '@/components/ShopCard.vue'
+import { log } from 'console';
 
 const orderTitle = ref('排序')
 const filterTitle = ref('篩選')
@@ -16,17 +17,45 @@ interface ResultItem {
   services: string[];
 }
 
-const results = ref<ResultItem[]>([
-  {
-    name: '咪咪毛毛',
-    score: 5,
-    distance: 1,
-    brands: ['咪咪', '毛毛'],
-    services: ['保養', '維修'],
-  },
-])
+const results = ref<ResultItem[]>([])
 
 const resultsCount = computed(() => results.value.length)
+try{ // 範例資料，實際應從API取得
+      results.value = [
+      {
+        id: 1,
+        name: '匠心汽車維修中心',
+        score: 5,
+        distance: 1.2,
+        brands: ['Benz', 'BMW', '奧迪', '保時捷'],
+        services: ['保養維護', '故障維修', '年檢服務', '鈑金噴漆', '輪胎更換', '冷氣維修'],
+        image: 'https://picsum.photos/300/200?random=1'
+      },
+      {
+        id: 2,
+        name: '職人汽車保養廠',
+        score: 4,
+        distance: 2.5,
+        brands: ['豐田', '本田', 'Volvo', '馬自達'],
+        services: ['定期保養', '引擎維修', '變速箱維修', '煞車系統', '電路檢修', '冷氣維修'],
+        image: 'https://picsum.photos/300/200?random=2'
+      },
+      {
+        id: 3,
+        name: '專業汽車維修站',
+        score: 4,
+        distance: 3.8,
+        brands: ['福斯', '奧迪', '保時捷', 'BMW'],
+        services: ['專業診斷', '原廠配件', '精密維修', '性能升級', '保養套餐', '質保服務'],
+        image: 'https://picsum.photos/300/200?random=3'
+      },
+    ];
+}catch(err){
+  console.log('沒有符合資料的結果:', err);
+
+}
+
+
 </script>
 
 <template>

--- a/src/components/SearchResults.vue
+++ b/src/components/SearchResults.vue
@@ -100,6 +100,7 @@ const handleViewDetail = (shopId: number) => {
   // TODO: 之後這裡會接路由跳轉
   alert(`查看商店 ID: ${shopId} 的詳細資料`);
 };
+
 onMounted(() => {
   fetchShops();
 });
@@ -138,14 +139,38 @@ onMounted(() => {
           </select>
         </div>
       </div>
+      <div class="mt-4 text-[#4a4a43] text-sm" v-if="allShops.length > 0">
+        <p>
+          <span class="font-semibold">顯示：</span>
+            <span v-if="filterBy === 'all'">全部</span>
+            <span v-else-if="filterBy === 'nearby'">附近（3公里內）</span>
+            <span v-else-if="filterBy === 'ratingGood'">評價 4 星以上</span>
+          <span class="mx-2">|</span>
+          <span class="font-semibold">排序：</span>
+            <span v-if="filterBy === 'all'">
+            <span v-if="sortBy === 'rating'">依評價</span>
+            <span v-else-if="sortBy === 'distance'">依距離</span>
+            <span v-else>依評論數</span>
+          </span>
+          <span v-else>
+            <!-- 篩選後 -->
+            <span v-if="sortBy === 'rating'">原始順序</span>
+            <span v-else-if="sortBy === 'distance'">依距離</span>
+            <span v-else>依評論數</span>
+          </span>
+          <span class="ml-2 text-gray-600">(共 {{ resultsCount }} 間)</span>
+        </p>
+      </div>
     </div>
   </section>
+
   <section class="pt-5 bg-[#f5f1ed] pb-10 min-h-[60vh]">
     <div class="container mx-auto">
       <div v-if="!resultsCount" class="text-center py-10">
         <p class="text-[#4a4a43] text-lg">查無相關結果</p>
+        <p class="text-[#4a4a43] text-sm mt-2">請嘗試調整篩選條件</p>
       </div>
-      <div v-else class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
+      <div v-else class="grid grid-cols-1 mx-2 md:grid-cols-2 mx-2 gap-3 lg:grid-cols-3 gap-5">
         <ShopCard
           v-for="shop in results"
           :key="shop.id"

--- a/src/components/ShopCard.vue
+++ b/src/components/ShopCard.vue
@@ -48,7 +48,7 @@ const handleViewDetail = () => {
         {{ shop.distance }} 公里
       </p>
       <div class="flex flex-row flex-wrap justify-start items-center gap-2 my-5">
-        <!-- 用Tag元件顯示 -->
+        //用Tag元件顯示
         <Tag
           v-for="(brand, index) in shop.brands"
           :key="`brand-${index}`"

--- a/src/components/ShopCard.vue
+++ b/src/components/ShopCard.vue
@@ -18,9 +18,9 @@ const emit = defineEmits<{
   viewDetail: [shopId: number]
 }>();
 // 星等邏輯
-//TODO:帶調整顯示星星數量
+//TODO:改成svg匯入
 const getStars = (score: number) => {
-  const fullStars = `<span class="material-symbols-outlined">kid_star</span>`.repeat(score);
+  const fullStars = `<span class="material-symbols-outlined text-yellow-400">kid_star</span>`.repeat(score);
   const emptyStars = `<span class="fill-icon material-symbols-outlined">kid_star</span>`.repeat(5 - score);
   return fullStars + emptyStars;
 };
@@ -40,16 +40,15 @@ const handleViewDetail = () => {
       class="w-full aspect-[3/2] object-cover"
     />
     <div class="px-5 py-3 text-[#4a4a43]">
-      <p class="my-1 font-semibold">{{ shop.name }}</p>
-      <p class="my-1">
+      <p class="my-2 font-semibold">{{ shop.name }}</p>
+      <p class="my-2">
         <span v-html="getStars(shop.score)"></span>
       </p>
         <p class="flex flex-row justify-start items-center my-1">
-        <span class="material-symbols-outlined pr-2">location_on</span>
+        <span class="material-symbols-outlined pr-2 mt-2">location_on</span>
         {{ shop.distance }} 公里
       </p>
       <div class="flex flex-row flex-wrap justify-start items-center gap-2 my-5">
-        //用Tag元件顯示
         <Tag
           v-for="(brand, index) in shop.brands"
           :key="`brand-${index}`"

--- a/src/components/ShopCard.vue
+++ b/src/components/ShopCard.vue
@@ -19,9 +19,10 @@ const emit = defineEmits<{
 }>();
 // 星等邏輯
 //TODO:帶調整顯示星星數量
-const starIcon = `<span class="material-symbols-outlined">kid_star</span>`;
 const getStars = (score: number) => {
-  return starIcon.repeat(score);
+  const fullStars = `<span class="material-symbols-outlined">kid_star</span>`.repeat(score);
+  const emptyStars = `<span class="fill-icon material-symbols-outlined">kid_star</span>`.repeat(5 - score);
+  return fullStars + emptyStars;
 };
 
 // 決定要傳送哪些卡

--- a/src/components/ShopCard.vue
+++ b/src/components/ShopCard.vue
@@ -18,6 +18,7 @@ const emit = defineEmits<{
   viewDetail: [shopId: number]
 }>();
 // 星等邏輯
+//TODO:帶調整顯示星星數量
 const starIcon = `<span class="material-symbols-outlined">kid_star</span>`;
 const getStars = (score: number) => {
   return starIcon.repeat(score);
@@ -43,7 +44,7 @@ const handleViewDetail = () => {
         <span v-html="getStars(shop.score)"></span>
       </p>
         <p class="flex flex-row justify-start items-center my-1">
-        <span class="material-symbols-outlined">location_on</span>
+        <span class="material-symbols-outlined pr-2">location_on</span>
         {{ shop.distance }} 公里
       </p>
       <div class="flex flex-row flex-wrap justify-start items-center gap-2 my-5">

--- a/src/components/ShopCard.vue
+++ b/src/components/ShopCard.vue
@@ -1,5 +1,37 @@
+<script setup lang="ts">
+  import Tag from './Tag.vue';
+interface Props {
+  shop: {
+    image?: string;  // 圖片網址
+    id: number;
+    name: string;
+    score: number;
+    distance: number;
+    brands: string[];
+    services: string[];
+  }
+}
+// 傳遞卡片資料
+const props = defineProps<Props>();
+
+const emit = defineEmits<{
+  viewDetail: [shopId: number]
+}>();
+// 星等邏輯
+const starIcon = `<span class="material-symbols-outlined">kid_star</span>`;
+const getStars = (score: number) => {
+  return starIcon.repeat(score);
+};
+
+// 決定要傳送哪些卡
+const handleViewDetail = () => {
+  emit('viewDetail', props.shop.id);
+};
+
+</script>
+
 <template>
-  <div class="shop-card">
+  <div class="grid ">
 
   </div>
 </template>

--- a/src/components/ShopCard.vue
+++ b/src/components/ShopCard.vue
@@ -1,0 +1,5 @@
+<template>
+  <div class="shop-card">
+
+  </div>
+</template>

--- a/src/components/ShopCard.vue
+++ b/src/components/ShopCard.vue
@@ -31,7 +31,44 @@ const handleViewDetail = () => {
 </script>
 
 <template>
-  <div class="grid ">
-
+  <div class="border border-[#DBCEBD] rounded-[5px] overflow-hidden hover:shadow-md duration-300 bg-white">
+    <img
+      :src="shop.image || 'https://picsum.photos/300/200?random=1'"
+      :alt="`${shop.name}環境圖片`"
+      class="w-full aspect-[3/2] object-cover"
+    />
+    <div class="px-5 py-3 text-[#4a4a43]">
+      <p class="my-1 font-semibold">{{ shop.name }}</p>
+      <p class="my-1">
+        <span v-html="getStars(shop.score)"></span>
+      </p>
+        <p class="flex flex-row justify-start items-center my-1">
+        <span class="material-symbols-outlined">location_on</span>
+        {{ shop.distance }} 公里
+      </p>
+      <div class="flex flex-row flex-wrap justify-start items-center gap-2 my-5">
+        <!-- 用Tag元件顯示 -->
+        <Tag
+          v-for="(brand, index) in shop.brands"
+          :key="`brand-${index}`"
+          :label="brand"
+          variant="filled"
+        />
+      </div>
+      <div class="flex flex-row flex-wrap justify-start items-center gap-2 my-5">
+        <Tag
+          v-for="(service, index) in shop.services"
+          :key="`service-${index}`"
+          :label="service"
+          variant="outlined"
+        />
+      </div>
+      <button
+        @click="handleViewDetail"
+        class="w-full block p-3 bg-[#8b7d6b] text-[14px] text-white rounded-[8px] cursor-pointer hover:bg-[#6d6250] transition-colors"
+      >
+        查看詳細資料
+      </button>
+    </div>
   </div>
 </template>

--- a/src/components/Tag.vue
+++ b/src/components/Tag.vue
@@ -9,6 +9,15 @@ const props = withDefaults(defineProps<CategoryTagProps>(),{
   variant: 'outlined',
 });
 
+const tagClass = computed(() => {
+  const baseClass = 'inline-block px-3 py-1 text-[14px] rounded-full';
+
+  if (props.variant === 'filled') {
+    return `${baseClass} bg-[#8b7d6b] text-white`;
+  } else {
+    return `${baseClass} bg-[#f5f1ed] text-[#8b7d6b] border border-[#8b7d6b]`;
+  }
+});
 
 </script>
 <template>

--- a/src/components/Tag.vue
+++ b/src/components/Tag.vue
@@ -1,0 +1,16 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+interface CategoryTagProps {
+  variant?: 'filled' | 'outlined';
+  label: string;
+}
+
+const props = withDefaults(defineProps<CategoryTagProps>(),{
+  variant: 'outlined',
+});
+
+
+</script>
+<template>
+
+</template>

--- a/src/components/Tag.vue
+++ b/src/components/Tag.vue
@@ -20,6 +20,10 @@ const tagClass = computed(() => {
 });
 
 </script>
+
 <template>
+  <span :class="tagClass">
+    {{ label }}
+  </span>
 
 </template>

--- a/src/main.css
+++ b/src/main.css
@@ -9,3 +9,6 @@
 .search-modal-check-icon.material-symbols-outlined {
   font-size: 48px;
 }
+.fill-icon{
+   font-variation-settings: 'FILL' 1;
+}


### PR DESCRIPTION
1.將 #27 頁面的卡片 改成以元件的方式製作:ShopCard.vue
其中 卡片內的分類標籤以 Tag.vue元件呈現，此元件後續也可應用於 #40  DetailView.vue內的標籤元素

2.星星邏輯待修改，目前是幾顆星show幾顆，想改成幾顆星是有顏色，少的星補空白星
EX: ☆☆☆ = ★★★☆☆

3.排序與篩選項目已補齊

網頁：
<img width="1301" height="608" alt="截圖 2026-01-07 晚上10 54 30" src="https://github.com/user-attachments/assets/68a00f42-d954-4c5f-abb8-614e0c24bfff" />
<img width="637" height="111" alt="截圖 2026-01-07 晚上10 54 37" src="https://github.com/user-attachments/assets/ce16a8fd-00a4-4e0a-b53a-6ed9a8242c01" />
<img width="622" height="145" alt="截圖 2026-01-07 晚上10 54 42" src="https://github.com/user-attachments/assets/9d2cebaf-a8f5-4235-adf7-573eeb856a94" />
平板：
<img width="722" height="535" alt="截圖 2026-01-07 晚上10 55 57" src="https://github.com/user-attachments/assets/71b07102-1c88-4740-8eb2-9e19d193c835" />
手機： （卡片margin待微調）
<img width="273" height="513" alt="截圖 2026-01-07 晚上10 56 13" src="https://github.com/user-attachments/assets/82247411-6a0c-4fe7-9dd7-7638a2ced2da" />
