### PR TITLE
#70 將Nato Serif TC字型導入專案

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ __screenshots__/
 
 *storybook.log
 storybook-static
+CLAUDE.md

--- a/index.html
+++ b/index.html
@@ -9,6 +9,11 @@
       rel="stylesheet"
       href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined"
     />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <!-- <link href="https://fonts.googleapis.com/css2?family=Shippori+Mincho:wght@400;700&display=swap" rel="stylesheet"> -->
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Serif+TC:wght@400;500;600;700;800;900&display=swap" rel="stylesheet">
+    
 
     <title>carE 汽車維修預約平台</title>
   </head>

--- a/src/components/layout/HeaderNavbar.vue
+++ b/src/components/layout/HeaderNavbar.vue
@@ -38,7 +38,7 @@ const closeRegister = () => {
           <span class="logo material-symbols-outlined text-[#6b6b5a]"> directions_car </span>
           <span class="text-[20px] sm:text-[24px] font-bold text-[#4a4a43]">carE</span>
         </a>
-        <div class="flex items-center gap-2 sm:gap-3">
+        <div class="flex items-center gap-2 sm:gap-3 font-extrabold">
           <button
             @click="openLoginModal"
             :class="[

--- a/src/main.css
+++ b/src/main.css
@@ -17,7 +17,7 @@
   --font-weight-semibold: 600;
   --font-weight-bold: 700;
   --font-weight-extrabold: 800;
-
+  --font-weight-Black: 900;
 }
 
 body {
@@ -29,5 +29,5 @@ body {
   letter-spacing: 0.5px;
 }
 h1, h2, h3, h4, h5, h6 {
-  font-weight: 900;
+  font-weight: 800;
 }

--- a/src/main.css
+++ b/src/main.css
@@ -9,3 +9,25 @@
 .search-modal-check-icon.material-symbols-outlined {
   font-size: 48px;
 }
+
+@theme {
+  --font-noto: "Noto Serif TC", serif;
+  --font-weight-normal: 400;
+  --font-weight-medium: 500;
+  --font-weight-semibold: 600;
+  --font-weight-bold: 700;
+  --font-weight-extrabold: 800;
+
+}
+
+body {
+  font-family: "Noto Serif TC", serif;
+  font-optical-sizing: auto;
+  font-weight: 600;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  letter-spacing: 0.5px;
+}
+h1, h2, h3, h4, h5, h6 {
+  font-weight: 900;
+}

--- a/src/views/Home/Home.vue
+++ b/src/views/Home/Home.vue
@@ -4,7 +4,7 @@
     <section
       class="text-center bg-[url(https://picsum.photos/id/605/1200/900)] bg-no-repeat bg-center bg-cover"
     >
-      <div class="mask flex flex-col justify-center items-center py-10 bg-[#f2f1eedd]">
+      <div class="mask flex flex-col justify-center items-center py-20 bg-[#f2f1eedd]">
         <h1 class="text-[36px] text-[#4a4a43] font-black">carE 汽車維修預約平台</h1>
         <h2 class="text-[28px] text-[#4a4a43] font-bold">尋找專業的汽車維修服務</h2>
         <h3 class="mb-[50px] text-[20px] text-[#8a8a7d] font-normal">
@@ -14,7 +14,7 @@
         <form
           action=""
           method="get"
-          class="flex flex-col lg:flex-row justify-evenly items-end gap-x-[50px] w-[80%] p-[20px] bg-[#fff] shadow-md rounded-[8px]"
+          class="flex flex-col lg:flex-row justify-evenly items-end gap-x-[50px] w-[80%] p-[20px] bg-[#fff] shadow-md rounded-[8px] font-bold"
         >
           <div class="w-full lg:w-[25%]">
             <label
@@ -133,12 +133,12 @@
         </form>
         <!-- 六大常見搜尋主題 -->
         <!-- TODO: button 待加 click event function -->
-        <h3 class="mt-[50px] text-[24px] text-[#4a4a43] font-bold">六大熱門搜尋主題</h3>
+        <h3 class="mt-[50px] text-[24px] text-[#4a4a43] pb-5 font-bold">六大熱門搜尋主題</h3>
         <div
           class="flex flex-row flex-wrap lg:flex-nowrap justify-evenly items-center w-full mt-[5%] lg:mt-[0%]"
         >
           <button
-            class="inline-block relative w-[150px] h-[150px] m-[10px] p-[10px] bg-[#f5f4f0] rounded-[1000px] cursor-pointer"
+            class="inline-block relative w-[150px] h-[150px] m-[10px] p-[10px] bg-[#f5f4f0] hover:bg-[#e5c58e] rounded-[1000px] cursor-pointer"
           >
             <p class="flex flex-col justify-evenly items-center text-[#4a4a43]">
               <span class="six-theme-icon material-symbols-outlined"> handyman </span>
@@ -146,7 +146,7 @@
             </p>
           </button>
           <button
-            class="inline-block relative w-[150px] h-[150px] m-[10px] p-[10px] bg-[#f5f4f0] rounded-[1000px] cursor-pointer"
+            class="inline-block relative w-[150px] h-[150px] m-[10px] p-[10px] bg-[#f5f4f0] hover:bg-[#e5c58e] rounded-[1000px] cursor-pointer"
           >
             <p class="flex flex-col justify-evenly items-center text-[#4a4a43]">
               <span class="six-theme-icon material-symbols-outlined"> directions_car </span>
@@ -154,7 +154,7 @@
             </p>
           </button>
           <button
-            class="inline-block relative w-[150px] h-[150px] m-[10px] p-[10px] bg-[#f5f4f0] rounded-[1000px] cursor-pointer"
+            class="inline-block relative w-[150px] h-[150px] m-[10px] p-[10px] bg-[#f5f4f0] hover:bg-[#e5c58e] rounded-[1000px] cursor-pointer"
           >
             <p class="flex flex-col justify-evenly items-center text-[#4a4a43]">
               <span class="six-theme-icon material-symbols-outlined"> build </span>
@@ -162,7 +162,7 @@
             </p>
           </button>
           <button
-            class="inline-block relative w-[150px] h-[150px] m-[10px] p-[10px] bg-[#f5f4f0] rounded-[1000px] cursor-pointer"
+            class="inline-block relative w-[150px] h-[150px] m-[10px] p-[10px] bg-[#f5f4f0] hover:bg-[#e5c58e] rounded-[1000px] cursor-pointer"
           >
             <p class="flex flex-col justify-evenly items-center text-[#4a4a43]">
               <span class="six-theme-icon material-symbols-outlined"> fragrance </span>
@@ -170,7 +170,7 @@
             </p>
           </button>
           <button
-            class="inline-block relative w-[150px] h-[150px] m-[10px] p-[10px] bg-[#f5f4f0] rounded-[1000px] cursor-pointer"
+            class="inline-block relative w-[150px] h-[150px] m-[10px] p-[10px] bg-[#f5f4f0] hover:bg-[#e5c58e] rounded-[1000px] cursor-pointer"
           >
             <p class="flex flex-col justify-evenly items-center text-[#4a4a43]">
               <span class="six-theme-icon material-symbols-outlined"> adjust </span>
@@ -178,7 +178,7 @@
             </p>
           </button>
           <button
-            class="inline-block relative w-[150px] h-[150px] m-[10px] p-[10px] bg-[#f5f4f0] rounded-[1000px] cursor-pointer"
+            class="inline-block relative w-[150px] h-[150px] m-[10px] p-[10px] bg-[#f5f4f0] hover:bg-[#e5c58e] rounded-[1000px] cursor-pointer"
           >
             <p class="flex flex-col justify-evenly items-center text-[#4a4a43]">
               <span class="six-theme-icon material-symbols-outlined"> car_crash </span>


### PR DESCRIPTION
1.原本預計使用，實際導入後覺得不合適，改以[Nato Serif TC](https://fonts.google.com/noto/specimen/Noto+Serif+TC?stylecount=5&lang=zh_Hant)進行
<img width="1415" height="677" alt="截圖 2026-01-11 清晨5 46 08" src="https://github.com/user-attachments/assets/edfce728-17dc-4ea5-8014-80405357f30c" />


- 有多個字重可以調用
<img width="716" height="508" alt="natoserifTC_weight" src="https://github.com/user-attachments/assets/b59b9bba-8ddb-45d8-984e-636ed98c03a2" />

2.微調了一些間距，並在首頁六大按鈕加上hover bg

https://github.com/user-attachments/assets/c2b6dbf8-79a0-43ac-a337-77902c510594

