### PR TITLE
#63-1 會員中心個人頁面(切版)

### DIFF
--- a/src/views/User/UserDashboard.vue
+++ b/src/views/User/UserDashboard.vue
@@ -1,33 +1,12 @@
 <script setup lang="ts">
-import { computed, ref } from "vue";
-
-type CarItem = {
-	Id: number;
-	Brand: string;
-	Model: string;
-	LicensePlate: string;
-	Color: string;
-};
-
-const MyCars = ref<CarItem[]>([
-	{
-		Id: 1,
-		Brand: `Toyota`,
-		Model: `Camry`,
-		LicensePlate: `ABC-1234`,
-		Color: `白色`,
-	},
-]);
-
-const PrimaryCar = computed<CarItem | null>(() => {
-	return MyCars.value[0] ?? null;
-});
+import { ref } from "vue";
 
 const IsEditing = ref(false);
 const Nickname = ref(`咪毛`);
 const Name = ref(`王貓貓`);
 const Email = ref(`mimimoumou@gmail.com`);
 const Phone = ref(`0912-345-678`);
+const LicensePlate = ref(`ABC-1234`);
 
 const ToggleEditing = (): void => {
 	IsEditing.value = !IsEditing.value;
@@ -41,11 +20,14 @@ const ToggleEditing = (): void => {
 				<h1 class="text-[#4a4540] tracking-wide">會員中心</h1>
 			</div>
 		</header>
+
 		<main class="max-w-5xl mx-auto px-6 py-8 md:py-10">
 			<div class="space-y-8">
+				<!-- 個人資料區塊 -->
 				<section class="space-y-6">
 					<div class="flex items-center justify-between">
 						<h2 class="text-[#4a4540]">個人資料</h2>
+
 						<button
 							type="button"
 							@click="ToggleEditing"
@@ -66,6 +48,7 @@ const ToggleEditing = (): void => {
 							</template>
 						</button>
 					</div>
+
 					<div class="bg-white border border-[#e8e4dc] rounded-2xl p-6 shadow-sm">
 						<div class="grid grid-cols-1 md:grid-cols-2 gap-5">
 							<div class="space-y-2">
@@ -80,6 +63,7 @@ const ToggleEditing = (): void => {
 									{{ Nickname }}
 								</p>
 							</div>
+
 							<div class="space-y-2">
 								<label class="block text-sm text-[#6b6460]">姓名</label>
 								<input
@@ -92,6 +76,7 @@ const ToggleEditing = (): void => {
 									{{ Name }}
 								</p>
 							</div>
+
 							<div class="space-y-2">
 								<label class="block text-sm text-[#6b6460]">電子郵件</label>
 								<input
@@ -104,6 +89,7 @@ const ToggleEditing = (): void => {
 									{{ Email }}
 								</p>
 							</div>
+
 							<div class="space-y-2">
 								<label class="block text-sm text-[#6b6460]">電話</label>
 								<input
@@ -116,49 +102,47 @@ const ToggleEditing = (): void => {
 									{{ Phone }}
 								</p>
 							</div>
-						</div>
-					</div>
-				</section>
-				<section class="space-y-4">
-					<button type="button" class="group flex w-full items-center justify-between border border-[#e8e4dc] rounded-2xl bg-white p-6 shadow-sm transition-all duration-200 hover:shadow-md">
-						<div class="flex items-center gap-4">
-							<div class="rounded-xl bg-[#f9f7f4] p-3">
-								<span class="material-symbols-outlined text-[24px] leading-none text-[#8b7f6f]">
-									directions_car
-								</span>
-							</div>
-							<div class="text-left">
-								<h3 class="mb-1 text-[#4a4540]">管理車輛登記</h3>
-								<div v-if="PrimaryCar" class="flex items-center gap-2">
-									<p class="text-sm text-[#6b6460]">
-										{{ PrimaryCar.Brand }} {{ PrimaryCar.Model }} · {{ PrimaryCar.LicensePlate }}
-									</p>
-									<span class="rounded-full bg-[#e8f0f7] px-2 py-0.5 text-xs text-[#7a9aae]">
-										目前展示
-									</span>
-								</div>
-								<p v-else class="text-sm text-[#b0a9a2]">
-									尚未登記任何車輛
+
+							<div class="space-y-2">
+								<label class="block text-sm text-[#6b6460]">車牌登記</label>
+								<input
+									v-if="IsEditing"
+									type="text"
+									v-model="LicensePlate"
+									class="w-full border border-[#e0dbd3] rounded-lg bg-[#f9f7f4] px-4 py-3 text-[#4a4540] focus:outline-none focus:ring-2 focus:ring-[#8b7f6f]/30"
+								/>
+								<p v-else class="px-4 py-3 text-[#4a4540]">
+									{{ LicensePlate }}
 								</p>
 							</div>
 						</div>
-						<span class="material-symbols-outlined text-[20px] leading-none text-[#8b7f6f] transition-transform duration-200 group-hover:translate-x-1">
-							chevron_right
-						</span>
-					</button>
-					<button type="button" class="group flex w-full items-center justify-between border border-[#e8e4dc] rounded-2xl bg-white p-6 shadow-sm transition-all duration-200 hover:shadow-md">
+					</div>
+				</section>
+
+				<!-- 移除：車輛管理（管理車輛登記） -->
+
+				<!-- 其他功能區塊 -->
+				<section class="space-y-4">
+					<button
+						type="button"
+						class="group flex w-full items-center justify-between border border-[#e8e4dc] rounded-2xl bg-white p-6 shadow-sm transition-all duration-200 hover:shadow-md"
+					>
 						<div class="flex items-center gap-4">
 							<div class="rounded-xl bg-[#f9f7f4] p-3">
 								<span class="material-symbols-outlined text-[24px] leading-none text-[#8b7f6f]">
 									handyman
 								</span>
 							</div>
+
 							<div class="text-left">
 								<h3 class="mb-1 text-[#4a4540]">送修記錄</h3>
 								<p class="text-sm text-[#6b6460]">查看所有送修紀錄與維修進度</p>
 							</div>
 						</div>
-						<span class="material-symbols-outlined text-[20px] leading-none text-[#8b7f6f] transition-transform duration-200 group-hover:translate-x-1">
+
+						<span
+							class="material-symbols-outlined text-[20px] leading-none text-[#8b7f6f] transition-transform duration-200 group-hover:translate-x-1"
+						>
 							chevron_right
 						</span>
 					</button>

--- a/src/views/User/UserDashboard.vue
+++ b/src/views/User/UserDashboard.vue
@@ -1,11 +1,10 @@
 <script setup lang="ts">
-import { ref } from "vue";
+import { computed, ref } from "vue";
 
 type CarItem = {
 	Id: number;
 	Brand: string;
 	Model: string;
-	Year: string;
 	LicensePlate: string;
 	Color: string;
 };
@@ -15,11 +14,14 @@ const MyCars = ref<CarItem[]>([
 		Id: 1,
 		Brand: `Toyota`,
 		Model: `Camry`,
-		Year: `2020`,
 		LicensePlate: `ABC-1234`,
 		Color: `白色`,
 	},
 ]);
+
+const PrimaryCar = computed<CarItem | null>(() => {
+	return MyCars.value[0] ?? null;
+});
 
 const IsEditing = ref(false);
 const Nickname = ref(`咪毛`);
@@ -118,42 +120,47 @@ const ToggleEditing = (): void => {
 					</div>
 				</section>
 				<section class="space-y-4">
-					<button
-						type="button"
-						class="group flex w-full items-center justify-between border border-[#e8e4dc] rounded-2xl bg-white p-6 shadow-sm transition-all duration-200 hover:shadow-md"
-					>
+					<button type="button" class="group flex w-full items-center justify-between border border-[#e8e4dc] rounded-2xl bg-white p-6 shadow-sm transition-all duration-200 hover:shadow-md">
 						<div class="flex items-center gap-4">
 							<div class="rounded-xl bg-[#f9f7f4] p-3">
-								<span class="material-symbols-outlined text-[24px] leading-none text-[#8b7f6f]">directions_car</span>
+								<span class="material-symbols-outlined text-[24px] leading-none text-[#8b7f6f]">
+									directions_car
+								</span>
 							</div>
 							<div class="text-left">
 								<h3 class="mb-1 text-[#4a4540]">管理車輛登記</h3>
-
-								<div class="flex items-center gap-2">
+								<div v-if="PrimaryCar" class="flex items-center gap-2">
 									<p class="text-sm text-[#6b6460]">
-										{{ MyCars[0].Brand }} {{ MyCars[0].Model }} · {{ MyCars[0].LicensePlate }}
+										{{ PrimaryCar.Brand }} {{ PrimaryCar.Model }} · {{ PrimaryCar.LicensePlate }}
 									</p>
-									<span class="rounded-full bg-[#e8f0f7] px-2 py-0.5 text-xs text-[#7a9aae]">目前展示</span>
+									<span class="rounded-full bg-[#e8f0f7] px-2 py-0.5 text-xs text-[#7a9aae]">
+										目前展示
+									</span>
 								</div>
+								<p v-else class="text-sm text-[#b0a9a2]">
+									尚未登記任何車輛
+								</p>
 							</div>
 						</div>
-						<span class="material-symbols-outlined text-[20px] leading-none text-[#8b7f6f] transition-transform duration-200 group-hover:translate-x-1">chevron_right</span>
+						<span class="material-symbols-outlined text-[20px] leading-none text-[#8b7f6f] transition-transform duration-200 group-hover:translate-x-1">
+							chevron_right
+						</span>
 					</button>
-					<button
-						type="button"
-						class="group flex w-full items-center justify-between border border-[#e8e4dc] rounded-2xl bg-white p-6 shadow-sm transition-all duration-200 hover:shadow-md"
-					>
+					<button type="button" class="group flex w-full items-center justify-between border border-[#e8e4dc] rounded-2xl bg-white p-6 shadow-sm transition-all duration-200 hover:shadow-md">
 						<div class="flex items-center gap-4">
 							<div class="rounded-xl bg-[#f9f7f4] p-3">
-								<span class="material-symbols-outlined text-[24px] leading-none text-[#8b7f6f]">handyman</span>
+								<span class="material-symbols-outlined text-[24px] leading-none text-[#8b7f6f]">
+									handyman
+								</span>
 							</div>
-
 							<div class="text-left">
 								<h3 class="mb-1 text-[#4a4540]">送修記錄</h3>
 								<p class="text-sm text-[#6b6460]">查看所有送修紀錄與維修進度</p>
 							</div>
 						</div>
-						<span class="material-symbols-outlined text-[20px] leading-none text-[#8b7f6f] transition-transform duration-200 group-hover:translate-x-1">chevron_right</span>
+						<span class="material-symbols-outlined text-[20px] leading-none text-[#8b7f6f] transition-transform duration-200 group-hover:translate-x-1">
+							chevron_right
+						</span>
 					</button>
 				</section>
 			</div>

--- a/src/views/User/UserDashboard.vue
+++ b/src/views/User/UserDashboard.vue
@@ -1,0 +1,179 @@
+<script setup lang="ts">
+import { ref } from "vue";
+
+type CarItem = {
+	Id: number;
+	Brand: string;
+	Model: string;
+	Year: string;
+	LicensePlate: string;
+	Color: string;
+};
+
+const MyCars = ref<CarItem[]>([
+	{
+		Id: 1,
+		Brand: `Toyota`,
+		Model: `Camry`,
+		Year: `2020`,
+		LicensePlate: `ABC-1234`,
+		Color: `白色`,
+	},
+]);
+
+const IsEditing = ref(false);
+const Nickname = ref(`小明`);
+const Name = ref(`王小明`);
+const Email = ref(`wang.xiaoming@example.com`);
+const Phone = ref(`0912-345-678`);
+
+const ToggleEditing = (): void => {
+	IsEditing.value = !IsEditing.value;
+};
+</script>
+
+<template>
+	<div class="min-h-screen bg-[#f4f1eb]">
+		<header class="bg-[#f9f7f4] border-b border-[#e0dbd3]">
+			<div class="max-w-5xl mx-auto px-6 py-5">
+				<h1 class="text-[#4a4540] tracking-wide">會員中心</h1>
+			</div>
+		</header>
+
+		<main class="max-w-5xl mx-auto px-6 py-8 md:py-10">
+			<div class="space-y-8">
+				<!-- 個人資料區塊 -->
+				<section class="space-y-6">
+					<div class="flex items-center justify-between">
+						<h2 class="text-[#4a4540]">個人資料</h2>
+
+						<button
+							type="button"
+							@click="ToggleEditing"
+							:class="[
+								'flex items-center gap-2 px-4 py-2 rounded-lg transition-colors duration-200',
+								IsEditing
+									? 'bg-[#8b7f6f] text-[#f9f7f4] hover:bg-[#7a6f5f]'
+									: 'bg-[#e8e4dc] text-[#6b6460] hover:bg-[#d9d3c9]',
+							]"
+						>
+							<template v-if="IsEditing">
+								<span class="material-symbols-outlined text-[18px] leading-none">save</span>
+								儲存
+							</template>
+							<template v-else>
+								<span class="material-symbols-outlined text-[18px] leading-none">edit</span>
+								編輯
+							</template>
+						</button>
+					</div>
+
+					<div class="bg-white border border-[#e8e4dc] rounded-2xl p-6 shadow-sm">
+						<div class="grid grid-cols-1 md:grid-cols-2 gap-5">
+							<div class="space-y-2">
+								<label class="block text-sm text-[#6b6460]">會員暱稱</label>
+
+								<input
+									v-if="IsEditing"
+									type="text"
+									v-model="Nickname"
+									class="w-full border border-[#e0dbd3] rounded-lg bg-[#f9f7f4] px-4 py-3 text-[#4a4540] focus:outline-none focus:ring-2 focus:ring-[#8b7f6f]/30"
+								/>
+								<p v-else class="px-4 py-3 text-[#4a4540]">
+									{{ Nickname }}
+								</p>
+							</div>
+
+							<div class="space-y-2">
+								<label class="block text-sm text-[#6b6460]">姓名</label>
+
+								<input
+									v-if="IsEditing"
+									type="text"
+									v-model="Name"
+									class="w-full border border-[#e0dbd3] rounded-lg bg-[#f9f7f4] px-4 py-3 text-[#4a4540] focus:outline-none focus:ring-2 focus:ring-[#8b7f6f]/30"
+								/>
+								<p v-else class="px-4 py-3 text-[#4a4540]">
+									{{ Name }}
+								</p>
+							</div>
+
+							<div class="space-y-2">
+								<label class="block text-sm text-[#6b6460]">電子郵件</label>
+
+								<input
+									v-if="IsEditing"
+									type="email"
+									v-model="Email"
+									class="w-full border border-[#e0dbd3] rounded-lg bg-[#f9f7f4] px-4 py-3 text-[#4a4540] focus:outline-none focus:ring-2 focus:ring-[#8b7f6f]/30"
+								/>
+								<p v-else class="px-4 py-3 text-[#4a4540]">
+									{{ Email }}
+								</p>
+							</div>
+
+							<div class="space-y-2">
+								<label class="block text-sm text-[#6b6460]">電話</label>
+
+								<input
+									v-if="IsEditing"
+									type="tel"
+									v-model="Phone"
+									class="w-full border border-[#e0dbd3] rounded-lg bg-[#f9f7f4] px-4 py-3 text-[#4a4540] focus:outline-none focus:ring-2 focus:ring-[#8b7f6f]/30"
+								/>
+								<p v-else class="px-4 py-3 text-[#4a4540]">
+									{{ Phone }}
+								</p>
+							</div>
+						</div>
+					</div>
+				</section>
+
+				<!-- 我的車輛區塊 -->
+				<section class="space-y-4">
+					<button
+						type="button"
+						class="group flex w-full items-center justify-between border border-[#e8e4dc] rounded-2xl bg-white p-6 shadow-sm transition-all duration-200 hover:shadow-md"
+					>
+						<div class="flex items-center gap-4">
+							<div class="rounded-xl bg-[#f9f7f4] p-3">
+								<span class="material-symbols-outlined text-[24px] leading-none text-[#8b7f6f]">directions_car</span>
+							</div>
+
+							<div class="text-left">
+								<h3 class="mb-1 text-[#4a4540]">管理車輛登記</h3>
+
+								<div class="flex items-center gap-2">
+									<p class="text-sm text-[#6b6460]">
+										{{ MyCars[0].Brand }} {{ MyCars[0].Model }} · {{ MyCars[0].LicensePlate }}
+									</p>
+									<span class="rounded-full bg-[#e8f0f7] px-2 py-0.5 text-xs text-[#7a9aae]">目前展示</span>
+								</div>
+							</div>
+						</div>
+
+						<span class="material-symbols-outlined text-[20px] leading-none text-[#8b7f6f] transition-transform duration-200 group-hover:translate-x-1">chevron_right</span>
+					</button>
+
+					<button
+						type="button"
+						class="group flex w-full items-center justify-between border border-[#e8e4dc] rounded-2xl bg-white p-6 shadow-sm transition-all duration-200 hover:shadow-md"
+					>
+						<div class="flex items-center gap-4">
+							<div class="rounded-xl bg-[#f9f7f4] p-3">
+								<span class="material-symbols-outlined text-[24px] leading-none text-[#8b7f6f]">handyman</span>
+							</div>
+
+							<div class="text-left">
+								<h3 class="mb-1 text-[#4a4540]">送修記錄</h3>
+								<p class="text-sm text-[#6b6460]">查看所有送修紀錄與維修進度</p>
+							</div>
+						</div>
+
+						<span class="material-symbols-outlined text-[20px] leading-none text-[#8b7f6f] transition-transform duration-200 group-hover:translate-x-1">chevron_right</span>
+					</button>
+				</section>
+			</div>
+		</main>
+	</div>
+</template>

--- a/src/views/User/UserDashboard.vue
+++ b/src/views/User/UserDashboard.vue
@@ -22,9 +22,9 @@ const MyCars = ref<CarItem[]>([
 ]);
 
 const IsEditing = ref(false);
-const Nickname = ref(`小明`);
-const Name = ref(`王小明`);
-const Email = ref(`wang.xiaoming@example.com`);
+const Nickname = ref(`咪毛`);
+const Name = ref(`王貓貓`);
+const Email = ref(`mimimoumou@gmail.com`);
 const Phone = ref(`0912-345-678`);
 
 const ToggleEditing = (): void => {
@@ -39,14 +39,11 @@ const ToggleEditing = (): void => {
 				<h1 class="text-[#4a4540] tracking-wide">會員中心</h1>
 			</div>
 		</header>
-
 		<main class="max-w-5xl mx-auto px-6 py-8 md:py-10">
 			<div class="space-y-8">
-				<!-- 個人資料區塊 -->
 				<section class="space-y-6">
 					<div class="flex items-center justify-between">
 						<h2 class="text-[#4a4540]">個人資料</h2>
-
 						<button
 							type="button"
 							@click="ToggleEditing"
@@ -67,12 +64,10 @@ const ToggleEditing = (): void => {
 							</template>
 						</button>
 					</div>
-
 					<div class="bg-white border border-[#e8e4dc] rounded-2xl p-6 shadow-sm">
 						<div class="grid grid-cols-1 md:grid-cols-2 gap-5">
 							<div class="space-y-2">
 								<label class="block text-sm text-[#6b6460]">會員暱稱</label>
-
 								<input
 									v-if="IsEditing"
 									type="text"
@@ -83,10 +78,8 @@ const ToggleEditing = (): void => {
 									{{ Nickname }}
 								</p>
 							</div>
-
 							<div class="space-y-2">
 								<label class="block text-sm text-[#6b6460]">姓名</label>
-
 								<input
 									v-if="IsEditing"
 									type="text"
@@ -97,10 +90,8 @@ const ToggleEditing = (): void => {
 									{{ Name }}
 								</p>
 							</div>
-
 							<div class="space-y-2">
 								<label class="block text-sm text-[#6b6460]">電子郵件</label>
-
 								<input
 									v-if="IsEditing"
 									type="email"
@@ -111,10 +102,8 @@ const ToggleEditing = (): void => {
 									{{ Email }}
 								</p>
 							</div>
-
 							<div class="space-y-2">
 								<label class="block text-sm text-[#6b6460]">電話</label>
-
 								<input
 									v-if="IsEditing"
 									type="tel"
@@ -128,8 +117,6 @@ const ToggleEditing = (): void => {
 						</div>
 					</div>
 				</section>
-
-				<!-- 我的車輛區塊 -->
 				<section class="space-y-4">
 					<button
 						type="button"
@@ -139,7 +126,6 @@ const ToggleEditing = (): void => {
 							<div class="rounded-xl bg-[#f9f7f4] p-3">
 								<span class="material-symbols-outlined text-[24px] leading-none text-[#8b7f6f]">directions_car</span>
 							</div>
-
 							<div class="text-left">
 								<h3 class="mb-1 text-[#4a4540]">管理車輛登記</h3>
 
@@ -151,10 +137,8 @@ const ToggleEditing = (): void => {
 								</div>
 							</div>
 						</div>
-
 						<span class="material-symbols-outlined text-[20px] leading-none text-[#8b7f6f] transition-transform duration-200 group-hover:translate-x-1">chevron_right</span>
 					</button>
-
 					<button
 						type="button"
 						class="group flex w-full items-center justify-between border border-[#e8e4dc] rounded-2xl bg-white p-6 shadow-sm transition-all duration-200 hover:shadow-md"
@@ -169,7 +153,6 @@ const ToggleEditing = (): void => {
 								<p class="text-sm text-[#6b6460]">查看所有送修紀錄與維修進度</p>
 							</div>
 						</div>
-
 						<span class="material-symbols-outlined text-[20px] leading-none text-[#8b7f6f] transition-transform duration-200 group-hover:translate-x-1">chevron_right</span>
 					</button>
 				</section>

--- a/src/views/User/UserDashboard.vue
+++ b/src/views/User/UserDashboard.vue
@@ -20,14 +20,11 @@ const ToggleEditing = (): void => {
 				<h1 class="text-[#4a4540] tracking-wide">會員中心</h1>
 			</div>
 		</header>
-
 		<main class="max-w-5xl mx-auto px-6 py-8 md:py-10">
 			<div class="space-y-8">
-				<!-- 個人資料區塊 -->
 				<section class="space-y-6">
 					<div class="flex items-center justify-between">
 						<h2 class="text-[#4a4540]">個人資料</h2>
-
 						<button
 							type="button"
 							@click="ToggleEditing"
@@ -48,7 +45,6 @@ const ToggleEditing = (): void => {
 							</template>
 						</button>
 					</div>
-
 					<div class="bg-white border border-[#e8e4dc] rounded-2xl p-6 shadow-sm">
 						<div class="grid grid-cols-1 md:grid-cols-2 gap-5">
 							<div class="space-y-2">
@@ -63,7 +59,6 @@ const ToggleEditing = (): void => {
 									{{ Nickname }}
 								</p>
 							</div>
-
 							<div class="space-y-2">
 								<label class="block text-sm text-[#6b6460]">姓名</label>
 								<input
@@ -76,7 +71,6 @@ const ToggleEditing = (): void => {
 									{{ Name }}
 								</p>
 							</div>
-
 							<div class="space-y-2">
 								<label class="block text-sm text-[#6b6460]">電子郵件</label>
 								<input
@@ -89,7 +83,6 @@ const ToggleEditing = (): void => {
 									{{ Email }}
 								</p>
 							</div>
-
 							<div class="space-y-2">
 								<label class="block text-sm text-[#6b6460]">電話</label>
 								<input
@@ -102,7 +95,6 @@ const ToggleEditing = (): void => {
 									{{ Phone }}
 								</p>
 							</div>
-
 							<div class="space-y-2">
 								<label class="block text-sm text-[#6b6460]">車牌登記</label>
 								<input
@@ -118,31 +110,20 @@ const ToggleEditing = (): void => {
 						</div>
 					</div>
 				</section>
-
-				<!-- 移除：車輛管理（管理車輛登記） -->
-
-				<!-- 其他功能區塊 -->
 				<section class="space-y-4">
-					<button
-						type="button"
-						class="group flex w-full items-center justify-between border border-[#e8e4dc] rounded-2xl bg-white p-6 shadow-sm transition-all duration-200 hover:shadow-md"
-					>
+					<button type="button" class="group flex w-full items-center justify-between border border-[#e8e4dc] rounded-2xl bg-white p-6 shadow-sm transition-all duration-200 hover:shadow-md">
 						<div class="flex items-center gap-4">
 							<div class="rounded-xl bg-[#f9f7f4] p-3">
 								<span class="material-symbols-outlined text-[24px] leading-none text-[#8b7f6f]">
 									handyman
 								</span>
 							</div>
-
 							<div class="text-left">
 								<h3 class="mb-1 text-[#4a4540]">送修記錄</h3>
 								<p class="text-sm text-[#6b6460]">查看所有送修紀錄與維修進度</p>
 							</div>
 						</div>
-
-						<span
-							class="material-symbols-outlined text-[20px] leading-none text-[#8b7f6f] transition-transform duration-200 group-hover:translate-x-1"
-						>
+						<span class="material-symbols-outlined text-[20px] leading-none text-[#8b7f6f] transition-transform duration-200 group-hover:translate-x-1">
 							chevron_right
 						</span>
 					</button>


### PR DESCRIPTION
### 會員中心個人頁面(切版)
會員的個人頁面，可以快速跳轉頁面查看登記車輛與送修紀錄。

`views/User/UserDashboard.vue`
> 該功能會與其他User分類的主功能串聯。

- 個人資料編輯。
- 送修記錄快捷按鈕。
- 電腦與手機的RWD。

---

<img width="709" height="588" alt="image" src="https://github.com/user-attachments/assets/df150bf5-c4cd-4b89-bfcb-111d1bdf5386" />
