### PR TITLE
#18-1 修改維修預約結果查看的顯示內容

### DIFF
--- a/frontend/src/views/User/RepairBookingList.vue
+++ b/frontend/src/views/User/RepairBookingList.vue
@@ -315,7 +315,7 @@ onBeforeUnmount(() => window.removeEventListener(`keydown`, HandleKeydown));
 						<button @click="CloseModal" class="flex h-10 w-10 items-center justify-center rounded-xl border border-[#E2DED6] transition-colors hover:bg-[#EFECE6]"><span class="material-symbols-outlined">close</span></button>
 					</div>
 					<div class="max-h-[78vh] overflow-y-auto px-6 py-6">
-						<div class="mb-6 flex flex-col justify-between gap-4 sm:flex-row sm:items-start">
+						<div class="mb-6 flex flex-row justify-between items-start gap-4">
 							<div class="min-w-0 flex-1">
 								<div class="mb-2 flex items-center gap-3">
 									<h4 class="text-lg font-bold">{{ SelectedAppointment.carModel }}</h4>
@@ -337,24 +337,12 @@ onBeforeUnmount(() => window.removeEventListener(`keydown`, HandleKeydown));
 								<p class="text-sm text-[#2F2E2A]">{{ SelectedAppointment.notes }}</p>
 							</div>
 						</div>
-						<div class="rounded-2xl bg-[#EFECE6]/60 p-6 text-[#2F2E2A]">
-							<div class="mb-4 flex items-center justify-between">
-								<h5 class="text-base font-bold">報價明細</h5>
-								<div class="text-sm font-bold">合計：{{ FormatCurrency(QuoteTotal) }}</div>
-							</div>
-							<div v-for="Grp in [{t:`基本維修`, d:QuoteGroups.base}, {t:`加購項目`, d:QuoteGroups.addon}]" :key="Grp.t" class="mb-6">
-								<p class="mb-3 text-[12px] font-bold text-[#6B705C]">{{ Grp.t }}</p>
-								<div v-if="Grp.d.length > 0" class="space-y-3">
-									<div v-for="(Item, Idx) in Grp.d" :key="Idx" class="flex justify-between text-sm py-1">
-										<span>{{ Item.name }}</span>
-										<span class="font-medium">{{ Item.price ? FormatCurrency(Item.price) : `待報價` }}</span>
-									</div>
-								</div>
-							</div>
-							<p class="mt-4 text-[12px] text-[#6B705C]">※ 此為展示用假資料（純切版）</p>
-						</div>
 					</div>
-					<div class="flex justify-end border-t border-[#E2DED6] bg-[#F7F5F0] px-6 py-4">
+					<div class="flex items-center justify-between border-t border-[#E2DED6] bg-[#F7F5F0] px-6 py-4">
+						<a href="#" class="flex items-center gap-2 text-sm font-medium text-[#6B705C] transition-colors hover:text-[#2F2E2A]">
+							<span class="material-symbols-outlined text-xl">download</span>
+							下載報價單
+						</a>
 						<button @click="CloseModal" class="rounded-xl border border-[#E2DED6] px-8 py-2.5 text-sm font-medium transition-colors hover:bg-[#EFECE6]">關閉</button>
 					</div>
 				</div>

--- a/frontend/src/views/User/RepairBookingList.vue
+++ b/frontend/src/views/User/RepairBookingList.vue
@@ -370,29 +370,14 @@ onBeforeUnmount(() => window.removeEventListener(`keydown`, HandleKeydown));
 							<p class="mb-4 text-sm font-bold text-[#2F2E2A]">您對本次維修服務滿意嗎？</p>
 							<div class="flex justify-center gap-2">
 								<button v-for="i in 5" :key="i" @click="RatingScore = i" @mouseenter="HoverScore = i" @mouseleave="HoverScore = 0" class="transition-transform active:scale-90">
-									<span :class="[`material-symbols-outlined text-4xl transition-colors`, (HoverScore || RatingScore) >= i ? `text-[#6B705C]` : `text-[#D9D6CF]`]" :style="`font-variation-settings: 'FILL' ${ (HoverScore || RatingScore) >= i ? 1 : 0 }` ">star</span>
+									<span :class="[`material-symbols-outlined text-4xl transition-colors`, (HoverScore || RatingScore) >= i ? `text-[#FFC107]` : `text-[#D9D6CF]`]" :style="`font-variation-settings: 'FILL' ${ (HoverScore || RatingScore) >= i ? 1 : 0 }` ">star</span>
 								</button>
 							</div>
 							<p v-if="RatingScore > 0" class="mt-3 text-xs font-bold text-[#6B705C]">{{ [`請評分`, `非常不滿意`, `需要改進`, `服務一般`, `滿意推薦`, `完美體驗！`][RatingScore] }}</p>
 						</div>
 						<div class="mb-8">
-							<p class="mb-4 text-sm font-bold text-[#2F2E2A]">選擇店家印象標籤</p>
-							<div class="flex flex-wrap gap-2">
-								<button v-for="Tag in ShopTags" :key="Tag" @click="ToggleTag(Tag)" :class="[`rounded-full border px-4 py-1.5 text-xs font-medium transition-all`, SelectedTags.includes(Tag) ? `border-[#6B705C] bg-[#6B705C] text-white` : `border-[#E2DED6] bg-white text-[#6B705C] hover:border-[#6B6B5C]`]">
-									{{ Tag }}
-								</button>
-							</div>
-						</div>
-						<div class="mb-8">
 							<p class="mb-3 text-sm font-bold text-[#2F2E2A]">詳細評論內容</p>
 							<textarea v-model="RatingComment" placeholder="分享您的維修心得與感受..." class="h-32 w-full resize-none rounded-xl border border-[#E2DED6] bg-white p-4 text-sm focus:border-[#6B705C] focus:outline-none"></textarea>
-						</div>
-						<div>
-							<p class="mb-3 text-sm font-bold text-[#2F2E2A]">上傳照片 (選填)</p>
-							<div class="flex h-20 w-20 cursor-pointer flex-col items-center justify-center rounded-xl border-2 border-dashed border-[#D9D6CF] text-[#6B705C] hover:bg-[#EFECE6]">
-								<span class="material-symbols-outlined text-2xl">add_a_photo</span>
-								<span class="text-[10px] mt-1">點擊上傳</span>
-							</div>
 						</div>
 					</div>
 					<div class="flex gap-3 border-t border-[#E2DED6] bg-[#F7F5F0] px-8 py-5">

--- a/frontend/src/views/User/RepairBookingList.vue
+++ b/frontend/src/views/User/RepairBookingList.vue
@@ -50,8 +50,6 @@ const SelectedAppointment = ref<Appointment | null>(null);
 const RatingScore = ref<number>(0);
 const HoverScore = ref<number>(0);
 const RatingComment = ref<string>(``);
-const SelectedTags = ref<string[]>([]);
-const ShopTags = [`技術專業`, `解說詳細`, `報價公道`, `服務親切`, `效率極高`, `原廠品質`];
 
 const StatusMap: Record<AppointmentStatus, { label: string; color: string }> = {
 	in_progress: { label: `維修中`, color: `text-[#2F2E2A] border-[#2F2E2A] bg-[#F7F5F0]` },
@@ -201,19 +199,12 @@ const OpenRatingModal = (Apt: Appointment) => {
 	SelectedAppointment.value = Apt;
 	RatingScore.value = 0;
 	RatingComment.value = ``;
-	SelectedTags.value = [];
 	ActiveModal.value = `rating`;
 };
 
 const CloseModal = () => {
 	ActiveModal.value = `none`;
 	SelectedAppointment.value = null;
-};
-
-const ToggleTag = (Tag: string) => {
-	const Index = SelectedTags.value.indexOf(Tag);
-	if (Index > -1) SelectedTags.value.splice(Index, 1);
-	else SelectedTags.value.push(Tag);
 };
 
 const SubmitRating = () => {
@@ -370,7 +361,7 @@ onBeforeUnmount(() => window.removeEventListener(`keydown`, HandleKeydown));
 							<p class="mb-4 text-sm font-bold text-[#2F2E2A]">您對本次維修服務滿意嗎？</p>
 							<div class="flex justify-center gap-2">
 								<button v-for="i in 5" :key="i" @click="RatingScore = i" @mouseenter="HoverScore = i" @mouseleave="HoverScore = 0" class="transition-transform active:scale-90">
-									<span :class="[`material-symbols-outlined text-4xl transition-colors`, (HoverScore || RatingScore) >= i ? `text-[#FFC107]` : `text-[#D9D6CF]`]" :style="`font-variation-settings: 'FILL' ${ (HoverScore || RatingScore) >= i ? 1 : 0 }` ">star</span>
+									<span :class="[`material-symbols-outlined text-4xl transition-colors`, (HoverScore || RatingScore) >= i ? `text-[#FFC107]` : `text-[#D9D6CF]`]" style="font-variation-settings: 'FILL' 1">star</span>
 								</button>
 							</div>
 							<p v-if="RatingScore > 0" class="mt-3 text-xs font-bold text-[#6B705C]">{{ [`請評分`, `非常不滿意`, `需要改進`, `服務一般`, `滿意推薦`, `完美體驗！`][RatingScore] }}</p>

--- a/frontend/src/views/User/RepairBookingList.vue
+++ b/frontend/src/views/User/RepairBookingList.vue
@@ -340,29 +340,9 @@ onBeforeUnmount(() => window.removeEventListener(`keydown`, HandleKeydown));
 								<span class="material-symbols-outlined text-[#6B705C] transition-transform duration-300" :class="{ 'rotate-180': ShowQuoteDetails }">expand_more</span>
 							</button>
 							<div v-if="ShowQuoteDetails" class="mt-4 overflow-hidden rounded-2xl border border-[#E2DED6] bg-white p-6 transition-all duration-300">
-								<div v-if="QuoteGroups.base.length > 0" class="mb-6">
-									<h6 class="mb-3 text-xs font-bold text-[#6B705C] uppercase tracking-wider">基本項目</h6>
-									<div class="space-y-2">
-										<div v-for="(Item, idx) in QuoteGroups.base" :key="idx" class="flex justify-between items-center text-sm">
-											<span class="text-[#2F2E2A]">{{ Item.name }}</span>
-											<span class="font-bold text-[#2F2E2A]">{{ typeof Item.price === 'number' ? FormatCurrency(Item.price) : '免費/內含' }}</span>
-										</div>
-									</div>
-								</div>
-								
-								<div v-if="QuoteGroups.addon.length > 0" class="mb-6">
-									<h6 class="mb-3 text-xs font-bold text-[#6B705C] uppercase tracking-wider">加購項目</h6>
-									<div class="space-y-2">
-										<div v-for="(Item, idx) in QuoteGroups.addon" :key="idx" class="flex justify-between items-center text-sm">
-											<span class="text-[#2F2E2A]">{{ Item.name }}</span>
-											<span class="font-bold text-[#2F2E2A]">{{ typeof Item.price === 'number' ? FormatCurrency(Item.price) : '免費/內含' }}</span>
-										</div>
-									</div>
-								</div>
-
-								<div class="flex justify-between items-center border-t border-[#E2DED6] pt-4">
-									<span class="text-base font-bold text-[#2F2E2A]">總計金額</span>
-									<span class="text-xl font-bold text-[#6B705C]">{{ FormatCurrency(QuoteTotal) }}</span>
+								<div class="flex flex-col items-center justify-center gap-2 py-2">
+									<span class="text-base font-bold text-[#2F2E2A]">預估總計金額</span>
+									<span class="text-3xl font-bold text-[#6B705C]">{{ FormatCurrency(QuoteTotal) }}</span>
 								</div>
 							</div>
 						</div>

--- a/frontend/src/views/User/RepairBookingList.vue
+++ b/frontend/src/views/User/RepairBookingList.vue
@@ -330,7 +330,6 @@ onBeforeUnmount(() => window.removeEventListener(`keydown`, HandleKeydown));
 								<p class="text-sm text-[#2F2E2A]">{{ SelectedAppointment.notes }}</p>
 							</div>
 						</div>
-
 						<div class="mb-6">
 							<button @click="ShowQuoteDetails = !ShowQuoteDetails" class="flex w-full items-center justify-between rounded-2xl border border-[#E2DED6] bg-[#F7F5F0] px-6 py-4 transition-colors hover:bg-[#EFECE6]">
 								<div class="flex items-center gap-2">

--- a/frontend/src/views/User/RepairBookingList.vue
+++ b/frontend/src/views/User/RepairBookingList.vue
@@ -47,6 +47,7 @@ const ActiveFilter = ref<FilterType>(`all`);
 const SearchQuery = ref<string>(``);
 const ActiveModal = ref<`none` | `detail` | `rating`>(`none`);
 const SelectedAppointment = ref<Appointment | null>(null);
+const ShowQuoteDetails = ref<boolean>(false);
 const RatingScore = ref<number>(0);
 const HoverScore = ref<number>(0);
 const RatingComment = ref<string>(``);
@@ -192,6 +193,7 @@ const GetProgressWidth = (Steps: ProgressStep[]) => {
 
 const OpenDetailModal = (Apt: Appointment) => {
 	SelectedAppointment.value = Apt;
+	ShowQuoteDetails.value = false;
 	ActiveModal.value = `detail`;
 };
 
@@ -326,6 +328,42 @@ onBeforeUnmount(() => window.removeEventListener(`keydown`, HandleKeydown));
 							<div class="rounded-2xl bg-[#EFECE6]/60 p-6">
 								<h5 class="mb-4 text-base font-bold text-[#2F2E2A]">備註</h5>
 								<p class="text-sm text-[#2F2E2A]">{{ SelectedAppointment.notes }}</p>
+							</div>
+						</div>
+
+						<div class="mb-6">
+							<button @click="ShowQuoteDetails = !ShowQuoteDetails" class="flex w-full items-center justify-between rounded-2xl border border-[#E2DED6] bg-[#F7F5F0] px-6 py-4 transition-colors hover:bg-[#EFECE6]">
+								<div class="flex items-center gap-2">
+									<span class="material-symbols-outlined text-[#6B705C]">request_quote</span>
+									<span class="font-bold text-[#2F2E2A]">查看預估報價單</span>
+								</div>
+								<span class="material-symbols-outlined text-[#6B705C] transition-transform duration-300" :class="{ 'rotate-180': ShowQuoteDetails }">expand_more</span>
+							</button>
+							<div v-if="ShowQuoteDetails" class="mt-4 overflow-hidden rounded-2xl border border-[#E2DED6] bg-white p-6 transition-all duration-300">
+								<div v-if="QuoteGroups.base.length > 0" class="mb-6">
+									<h6 class="mb-3 text-xs font-bold text-[#6B705C] uppercase tracking-wider">基本項目</h6>
+									<div class="space-y-2">
+										<div v-for="(Item, idx) in QuoteGroups.base" :key="idx" class="flex justify-between items-center text-sm">
+											<span class="text-[#2F2E2A]">{{ Item.name }}</span>
+											<span class="font-bold text-[#2F2E2A]">{{ typeof Item.price === 'number' ? FormatCurrency(Item.price) : '免費/內含' }}</span>
+										</div>
+									</div>
+								</div>
+								
+								<div v-if="QuoteGroups.addon.length > 0" class="mb-6">
+									<h6 class="mb-3 text-xs font-bold text-[#6B705C] uppercase tracking-wider">加購項目</h6>
+									<div class="space-y-2">
+										<div v-for="(Item, idx) in QuoteGroups.addon" :key="idx" class="flex justify-between items-center text-sm">
+											<span class="text-[#2F2E2A]">{{ Item.name }}</span>
+											<span class="font-bold text-[#2F2E2A]">{{ typeof Item.price === 'number' ? FormatCurrency(Item.price) : '免費/內含' }}</span>
+										</div>
+									</div>
+								</div>
+
+								<div class="flex justify-between items-center border-t border-[#E2DED6] pt-4">
+									<span class="text-base font-bold text-[#2F2E2A]">總計金額</span>
+									<span class="text-xl font-bold text-[#6B705C]">{{ FormatCurrency(QuoteTotal) }}</span>
+								</div>
 							</div>
 						</div>
 					</div>


### PR DESCRIPTION
### 修改維修預約結果查看的顯示內容
維修預約頁面查看清單，可以查看當前送修的車輛以及維修進度。完成的訂單可以評價。
同時留了進入後端的前置作業。

`views/User/RepairBookingList.vue`
> 該功能會與其他User分類以及後端維修廠的功能串聯。

- 移除了報價單的詳細清單，會改成維修廠拍照後發送照片。
查看詳細頁面則顯示一個按鈕可以看報價金額(討論後一些比較隱私的資料預設不直接顯示)。
- 移除評價時會有的印象標籤。
- 修復了星星沒有正確被FILL 1影響的狀況。
- "維修中tag"在手機的RWD顯示改為跟PC一樣顯示在右上。

---
<img width="841" height="658" alt="image" src="https://github.com/user-attachments/assets/605e6d27-d785-4810-867b-df684a7b3800" />