### PR TITLE
#13-1 修改車廠介紹頁面(切版)

### DIFF
--- a/frontend/src/views/Search/components/DetailView.vue
+++ b/frontend/src/views/Search/components/DetailView.vue
@@ -19,6 +19,28 @@
                 <span>(02) 2345-6789</span>
               </div>
             </div>
+
+            <div class="mt-6">
+              <h3 class="mb-2 font-medium text-gray-800">環境照片</h3>
+              <div class="grid grid-cols-4 gap-2 h-32">
+                <div class="rounded-lg overflow-hidden bg-gray-100">
+                  <img src="https://picsum.photos/300/200?random=10" alt="環境照片1" class="w-full h-full object-cover hover:scale-110 transition-transform duration-300" />
+                </div>
+                <div class="rounded-lg overflow-hidden bg-gray-100">
+                  <img src="https://picsum.photos/300/200?random=11" alt="環境照片2" class="w-full h-full object-cover hover:scale-110 transition-transform duration-300" />
+                </div>
+                <div class="rounded-lg overflow-hidden bg-gray-100">
+                  <img src="https://picsum.photos/300/200?random=12" alt="環境照片3" class="w-full h-full object-cover hover:scale-110 transition-transform duration-300" />
+                </div>
+                <div class="relative rounded-lg overflow-hidden bg-gray-100 cursor-pointer group">
+                  <img src="https://picsum.photos/300/200?random=13" alt="環境照片4" class="w-full h-full object-cover group-hover:scale-110 transition-transform duration-300" />
+                  <div class="absolute inset-0 bg-black/40 flex items-center justify-center text-white text-sm font-medium opacity-0 group-hover:opacity-100 transition-opacity">
+                    +5 張
+                  </div>
+                </div>
+              </div>
+            </div>
+
             <div class="mt-6">
               <h3 class="mb-2 font-medium text-gray-800">專修品牌</h3>
               <div class="flex flex-wrap gap-2">

--- a/frontend/src/views/Search/components/DetailView.vue
+++ b/frontend/src/views/Search/components/DetailView.vue
@@ -1,3 +1,10 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+
+const isOpenMap = ref(false)
+const isOpenSurroundings = ref(false)
+</script>
+
 <template>
   <div class="min-h-screen py-8 bg-[#FAF8F5] min-w-[450px]">
     <div class="max-w-6xl mx-auto px-4">
@@ -15,14 +22,13 @@
             <div class="mt-4 space-y-2 text-sm text-gray-600">
               <div class="flex items-center gap-2">
                 <span>店長姓名:</span>
-                <span>陳大明</span>
+                <span>陳貓貓</span>
               </div>
               <div class="flex items-center gap-2">
                 <span>聯絡電話:</span>
                 <span>(02) 2345-6789</span>
               </div>
             </div>
-
             <div class="mt-6">
               <h3 class="mb-2 font-medium text-gray-800">環境照片</h3>
               <div class="grid grid-cols-4 gap-2 h-32">
@@ -43,7 +49,6 @@
                 </div>
               </div>
             </div>
-
             <div class="mt-6">
               <h3 class="mb-2 font-medium text-gray-800">專修品牌</h3>
               <div class="flex flex-wrap gap-2">
@@ -72,6 +77,74 @@
               </div>
             </div>
             <button class="w-full mt-8 py-3 text-white bg-[#6B6B5C] rounded-xl transition hover:opacity-90">立即預約</button>
+
+            <!-- 手機版折疊選單 (接在立即預約下方) -->
+            <div class="mt-6 space-y-4 lg:hidden">
+              <!-- 地圖折疊 -->
+              <div class="border border-gray-200 rounded-xl overflow-hidden">
+                <button
+                  @click="isOpenMap = !isOpenMap"
+                  class="w-full flex items-center justify-between p-4 bg-gray-50 hover:bg-gray-100 transition-colors"
+                >
+                  <span class="font-medium text-gray-800">維修廠地圖地點</span>
+                  <span class="transform transition-transform duration-200" :class="{ 'rotate-180': isOpenMap }">▼</span>
+                </button>
+                <div v-show="isOpenMap" class="p-4 bg-white border-t border-gray-200">
+                  <div class="w-full aspect-square bg-gray-100 rounded-xl border border-gray-200 flex flex-col items-center justify-center text-gray-400">
+                    <span class="text-4xl mb-2">🗺️</span>
+                    <span class="text-sm">Google Map 載入中...</span>
+                  </div>
+                  <div class="mt-4 text-sm text-gray-500">
+                    <p>地址：台北市咪咪毛毛區 123 號</p>
+                  </div>
+                  <button class="mt-4 w-full py-2 text-sm text-[#6B6B5C] bg-[#FAF8F5] border border-[#E8E3DB] rounded-lg hover:bg-[#E8E3DB] transition">開啟 Google Maps 導航</button>
+                </div>
+              </div>
+              <!-- 周邊休息折疊 -->
+              <div class="border border-gray-200 rounded-xl overflow-hidden">
+                <button
+                  @click="isOpenSurroundings = !isOpenSurroundings"
+                  class="w-full flex items-center justify-between p-4 bg-gray-50 hover:bg-gray-100 transition-colors"
+                >
+                  <span class="font-medium text-gray-800">周邊休息地點</span>
+                  <span class="transform transition-transform duration-200" :class="{ 'rotate-180': isOpenSurroundings }">▼</span>
+                </button>
+                <div v-show="isOpenSurroundings" class="p-4 bg-white border-t border-gray-200">
+                  <div class="space-y-4">
+                    <div class="flex gap-3 p-3 border border-gray-100 rounded-xl transition hover:bg-gray-50">
+                      <div class="flex items-center justify-center flex-shrink-0 w-10 h-10 text-xl bg-[#FAF8F5] rounded-lg">☕</div>
+                      <div class="flex-1 min-w-0">
+                        <div class="flex items-center justify-between mb-1">
+                          <h4 class="text-sm font-medium text-gray-900 truncate">路易莎咖啡 咪咪店</h4>
+                          <span class="px-1.5 py-0.5 text-[10px] text-[#6B6B5C] bg-[#E8E3DB] rounded">步行 3 分鐘</span>
+                        </div>
+                        <p class="text-xs text-gray-600 line-clamp-2">提供免費 WiFi 與插座，不限時。</p>
+                      </div>
+                    </div>
+                    <div class="flex gap-3 p-3 border border-gray-100 rounded-xl transition hover:bg-gray-50">
+                      <div class="flex items-center justify-center flex-shrink-0 w-10 h-10 text-xl bg-[#FAF8F5] rounded-lg">🏪</div>
+                      <div class="flex-1 min-w-0">
+                        <div class="flex items-center justify-between mb-1">
+                          <h4 class="text-sm font-medium text-gray-900 truncate">7-11 毛毛門市</h4>
+                          <span class="px-1.5 py-0.5 text-[10px] text-[#6B6B5C] bg-[#E8E3DB] rounded">步行 1 分鐘</span>
+                        </div>
+                        <p class="text-xs text-gray-600 line-clamp-2">店內設有寬敞用餐區與廁所。</p>
+                      </div>
+                    </div>
+                    <div class="flex gap-3 p-3 border border-gray-100 rounded-xl transition hover:bg-gray-50">
+                      <div class="flex items-center justify-center flex-shrink-0 w-10 h-10 text-xl bg-[#FAF8F5] rounded-lg">🌳</div>
+                      <div class="flex-1 min-w-0">
+                        <div class="flex items-center justify-between mb-1">
+                          <h4 class="text-sm font-medium text-gray-900 truncate">毛毛防災公園</h4>
+                          <span class="px-1.5 py-0.5 text-[10px] text-[#6B6B5C] bg-[#E8E3DB] rounded">步行 8 分鐘</span>
+                        </div>
+                        <p class="text-xs text-gray-600 line-clamp-2">天氣好時適合散步。</p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
           </section>
           <section class="p-6 bg-white rounded-2xl shadow-sm">
             <div class="flex items-center gap-2 mb-6">
@@ -148,7 +221,7 @@
             <button class="w-full mt-6 py-2 text-sm text-gray-500 border border-gray-200 rounded-lg hover:bg-gray-50 transition">查看更多評論</button>
           </section>
         </div>
-        <div class="w-full lg:w-[320px] flex-shrink-0">
+        <div class="w-full lg:w-[320px] flex-shrink-0 hidden lg:block">
           <div class="sticky top-8 space-y-6">
             <div class="p-6 bg-white rounded-2xl shadow-sm">
               <h3 class="mb-4 font-medium text-gray-800">維修廠地圖地點</h3>

--- a/frontend/src/views/Search/components/DetailView.vue
+++ b/frontend/src/views/Search/components/DetailView.vue
@@ -6,13 +6,16 @@
         <div class="flex-1 w-full min-w-0 space-y-6">
           <section class="p-6 bg-white rounded-2xl shadow-sm">
             <div class="flex items-start justify-between">
-              <h1 class="text-xl font-semibold text-gray-900">匠心汽車維修中心</h1>
+              <div class="flex items-end gap-3">
+                <h1 class="text-xl font-semibold text-gray-900">匠心汽車維修中心</h1>
+                <span class="text-xs text-gray-500 mb-1">台北市咪咪毛毛區 123 號</span>
+              </div>
               <div class="text-yellow-400">★★★★★</div>
             </div>
             <div class="mt-4 space-y-2 text-sm text-gray-600">
               <div class="flex items-center gap-2">
-                <span>店家地址:</span>
-                <span>台北市咪咪毛毛區 123 號</span>
+                <span>店長姓名:</span>
+                <span>陳大明</span>
               </div>
               <div class="flex items-center gap-2">
                 <span>聯絡電話:</span>
@@ -53,7 +56,7 @@
             </div>
             <div class="mt-6">
               <h3 class="mb-2 font-medium text-gray-800">服務項目</h3>
-              <div class="flex flex-col gap-2 text-sm text-gray-700 sm:flex-row sm:gap-12">
+              <div class="flex flex-row gap-8 text-sm text-gray-700 sm:gap-12">
                 <ul class="pl-4 space-y-1 list-disc">
                   <li>定期保養</li>
                   <li>變速箱維修</li>

--- a/frontend/src/views/Search/components/DetailView.vue
+++ b/frontend/src/views/Search/components/DetailView.vue
@@ -7,7 +7,7 @@
           <section class="p-6 bg-white rounded-2xl shadow-sm">
             <div class="flex items-start justify-between">
               <h1 class="text-xl font-semibold text-gray-900">匠心汽車維修中心</h1>
-              <div class="text-gray-500">★★★★★</div>
+              <div class="text-yellow-400">★★★★★</div>
             </div>
             <div class="mt-4 space-y-2 text-sm text-gray-600">
               <div class="flex items-center gap-2">
@@ -62,7 +62,7 @@
                       <span class="font-medium">U貓貓</span>
                       <span class="text-gray-400">2025-12-27</span>
                     </div>
-                    <div class="text-gray-500">★★★★★</div>
+                    <div class="text-yellow-400">★★★★★</div>
                   </div>
                   <p class="mt-2 text-sm leading-relaxed text-gray-600">
                     老闆技術很好，檢查很仔細，雖然是老車但也修得跟新的一樣！原本以為變速箱要大修，結果只是小零件問題，非常誠實的店家，大推！
@@ -87,7 +87,7 @@
                       <span class="font-medium">D貓貓</span>
                       <span class="text-gray-400">2025-12-20</span>
                     </div>
-                    <div class="text-gray-500">★★★★★</div>
+                    <div class="text-yellow-400">★★★★★</div>
                   </div>
                   <p class="mt-2 text-sm leading-relaxed text-gray-600">
                     冷氣突然不冷，跑了好幾家都說要換整組，這裡師傅幫我抓到是管路洩漏，補好灌冷媒就超級冷，省了一大筆錢！休息區還有路易莎咖啡可以喝，很貼心。
@@ -112,7 +112,7 @@
                       <span class="font-medium">T貓貓</span>
                       <span class="text-gray-400">2025-12-15</span>
                     </div>
-                    <div class="text-gray-500">★★★★☆</div>
+                    <div class="text-yellow-400">★★★★☆</div>
                   </div>
                   <p class="mt-2 text-sm leading-relaxed text-gray-600">
                     定期保養速度很快，價格公道透明。唯一的缺點是假日人有點多，建議大家要提早預約才不會等太久。


### PR DESCRIPTION
### 修改車廠介紹頁面(切版)

車廠介紹頁面做了視覺統一的變更，其中手機RWD的排版有了新的解決辦法。

`views/Search/components/DetailView.vue`

> 該功能會與搜尋服務以及後端維修廠的功能有串聯。

- 星星改為實心黃色。
- 介紹的區塊更動設計，裡面新增gallary的展示列，讓維修廠展示環境照片。
- 店家地址改到維修廠旁邊，原本的位置則改成店長姓名作為聯絡資訊。
- 手機RWD的"服務項目"現在跟PC一樣的縮排方式。
- “Google map”與“休息地點”區塊現在在手機的解析度情況下會變成折點選單放在立即預約按鈕底下。

---
<img width="1934" height="1014" alt="image" src="https://github.com/user-attachments/assets/1df68e08-ea88-4143-aab7-a708e029160a" />

### 折疊選單
<img width="455" height="330" alt="image" src="https://github.com/user-attachments/assets/ff7f010f-f49c-4c43-8b9b-e289f4217b02" />
