### PR TITLE
#rebuild-2 推送hotfix前端部署更新錯誤原因，路徑名稱錯誤

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import HeaderNavbar from '@/components/Layout/HeaderNavbar.vue';
+import HeaderNavbar from '@/components/layout/HeaderNavbar.vue';
 import Home from '@/views/Home/Home.vue';
-import Footer from '@/components/Layout/Footer.vue';
+import Footer from '@/components/layout/Footer.vue';
 import SearchResults from '@/views/Search/SearchResults.vue';
 import DetailView from '@/components/Search/DetailView.vue';
 import ServiceSearchFlow from '@/components/service-search/ServiceSearchFlow.vue';


### PR DESCRIPTION
GitHub倉庫在上一次merger把同名文件大小寫忽略，繼續沿用小寫。

原推送:
`components/Layout`

Hotfix更正:
`components/layout`