### PR TITLE
#rebuild-2 前端部署Hotfix，types路徑在整理時未更新導致打包錯誤

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import HeaderNavbar from '@/components/Layout/HeaderNavbar.vue';
+import HeaderNavbar from '@/components/layout/HeaderNavbar.vue';
 import Home from '@/views/Home/Home.vue';
-import Footer from '@/components/Layout/Footer.vue';
+import Footer from '@/components/layout/Footer.vue';
 import SearchResults from '@/views/Search/SearchResults.vue';
 import DetailView from '@/components/Search/DetailView.vue';
 import ServiceSearchFlow from '@/components/service-search/ServiceSearchFlow.vue';

--- a/frontend/src/components/GarageAdmin/OrderCard.vue
+++ b/frontend/src/components/GarageAdmin/OrderCard.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { statusClass } from '@/utils/orderStatus';
-import type { Order } from './types';
+import type { Order } from '@/types/garage';
 
 defineProps<{
   order: Order;

--- a/frontend/src/components/GarageAdmin/OrderDetailModal.vue
+++ b/frontend/src/components/GarageAdmin/OrderDetailModal.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref, watch } from 'vue';
 import { statusClass } from '@/utils/orderStatus';
-import type { Order, OrderStatus } from './types';
+import type { Order, OrderStatus } from '@/types/garage';
 
 const props = defineProps<{
   modelValue: boolean;

--- a/frontend/src/components/GarageAdmin/RecordCard.vue
+++ b/frontend/src/components/GarageAdmin/RecordCard.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref, computed } from 'vue';
-import type { CustomerProfile } from './types';
+import type { CustomerProfile } from '@/types/garage';
 
 const props = defineProps<{
   carOwner: CustomerProfile;


### PR DESCRIPTION
在整理時沒有把元件引入ts檔的路徑更新。
frontend/src/components/GarageAdmin/...

- OrderCard.vue
- OrderDetailModal.vue
- RecordCard.vue

原推送:
`import type { Order } from './types';`
`import type { Order, OrderStatus } from './types;`
`import type { CustomerProfile } from './types';`

Hotfix更正:
`import type { Order } from '@/types/garage';`
`import type { Order, OrderStatus } from '@/types/garage';`
`import type { CustomerProfile } from '@/types/garage';`