### PR TITLE
修改：修改google第三方登錄設定和刊登維修廠電話欄位

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .env
 .env.local
 .env.*.local
+.env.production
 
 # Logs
 logs

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,6 +1,7 @@
 # 伺服器設定
 PORT=3000
 NODE_ENV=development
+FRONTEND_URL=http://localhost:5173
 
 # 資料庫設定
 DB_HOST=localhost
@@ -12,8 +13,3 @@ DB_PASSWORD=your_password_here
 # JWT 設定
 JWT_SECRET=your_secret_key_here
 JWT_EXPIRES_IN=
-
-# Google OAuth 設定
-GOOGLE_CLIENT_ID=your_client_id_here
-GOOGLE_CLIENT_SECRET=your_client_secret_here
-GOOGLE_CALLBACK_URL=http://localhost:3000/auth/google/callback

--- a/frontend/.env.production.example
+++ b/frontend/.env.production.example
@@ -1,0 +1,11 @@
+# Supabase 配置
+VITE_SUPABASE_URL=your_supabase_url
+VITE_SUPABASE_ANON_KEY=your_supabase_anon_key
+
+# 後端 API URL（生產環境）
+VITE_API_URL=your_backend_url
+
+# 使用說明：
+# 1. 複製此檔案為 .env.production
+# 2. 填入實際的環境變數值
+# 3. 或在 Zeabur 的環境變數設定頁面直接設定

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -2,6 +2,19 @@ import { createRouter, createWebHistory } from 'vue-router';
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
+  // 路由跳轉後的滾動行為
+  scrollBehavior(to, from, savedPosition) {
+    if (savedPosition) {
+      return savedPosition;
+    }
+    if (to.hash) {
+      return {
+        el: to.hash,
+        behavior: 'smooth',
+      };
+    }
+    return { top: 0, behavior: 'smooth' };
+  },
   routes: [
     {
       path: '/',

--- a/frontend/src/views/Garage/GarageOnboarding.vue
+++ b/frontend/src/views/Garage/GarageOnboarding.vue
@@ -166,7 +166,8 @@ const startCountdown = () => {
 
     if (countdown.value <= 0) {
       clearCountdownTimer();
-      router.push('/garage/profile');
+      //TODO: 跳轉到商家編輯頁面
+      router.push('/');
     }
   }, 1000);
 };

--- a/frontend/src/views/Garage/GarageOnboarding.vue
+++ b/frontend/src/views/Garage/GarageOnboarding.vue
@@ -202,7 +202,7 @@ onUnmounted(() => {
             type="tel"
             placeholder="0912345678 或 02-12345678"
             inputmode="numeric"
-            pattern="[0-9-]*"
+            pattern="[0-9\-]*"
             required
             :error="showError('phone') ? errors.phone : ''"
             @blur="handleBlur('phone')"


### PR DESCRIPTION
1.supabase 重建後，重新串設定
成功：
<img width="1163" height="356" alt="截圖 2026-01-22 上午10 30 30" src="https://github.com/user-attachments/assets/268e47c8-64c0-4a65-a846-472659e01f68" />

2.另外一併處理了申請維修廠電話欄位驗證設定
還有修正 刊登維修廠 頁面按鈕按下後跳轉填寫表單的位置回到最上面
<img width="904" height="760" alt="填表跳轉滾動" src="https://github.com/user-attachments/assets/87b19099-d682-4046-9049-662b16dcc8d6" />

3.並先修正驗證完回到首頁的路徑＞＞待補跳轉商家資料編輯頁