### PR TITLE
#162 試用方案30天 倒數邏輯

### DIFF
--- a/frontend/src/components/subscription/TrialExpiryBanner.vue
+++ b/frontend/src/components/subscription/TrialExpiryBanner.vue
@@ -8,7 +8,7 @@ const subscriptionStore = useSubscriptionStore();
 const bannerStyle = computed(() => {
   const days = subscriptionStore.daysRemaining;
 
-  if (!days) return null;
+  if (days === null) return null;
 
   if (days === 0) {
     return {
@@ -42,7 +42,7 @@ const bannerStyle = computed(() => {
 const message = computed(() => {
   const days = subscriptionStore.daysRemaining;
 
-  if (!days) return '';
+  if (days === null) return '';
 
   if (days === 0) {
     return '您的試用期已到期，目前僅保留「商家資料展示」功能。';

--- a/frontend/src/components/subscription/TrialExpiryBanner.vue
+++ b/frontend/src/components/subscription/TrialExpiryBanner.vue
@@ -69,7 +69,6 @@ function goToUpgrade() {
     :class="[bannerStyle?.bg, bannerStyle?.border]"
   >
     <div class="flex items-start gap-3">
-      <!-- Icon -->
       <span
         class="material-symbols-outlined text-2xl mt-0.5"
         :class="bannerStyle?.icon"
@@ -77,7 +76,6 @@ function goToUpgrade() {
         {{ subscriptionStore.isExpired ? 'error' : 'schedule' }}
       </span>
 
-      <!-- Content -->
       <div class="flex-1">
         <p class="font-semibold mb-1" :class="bannerStyle?.text">
           {{ subscriptionStore.isExpired ? '試用期已到期' : '試用期即將到期' }}
@@ -87,7 +85,6 @@ function goToUpgrade() {
           升級至永久會員，享有完整功能！
         </p>
 
-        <!-- Action Button -->
         <button
           @click="goToUpgrade"
           class="px-4 py-2 text-sm font-semibold text-white rounded-lg transition-colors"

--- a/frontend/src/components/subscription/TrialExpiryBanner.vue
+++ b/frontend/src/components/subscription/TrialExpiryBanner.vue
@@ -1,0 +1,113 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useRouter } from 'vue-router';
+import { useSubscriptionStore } from '@/stores/subscription';
+
+const router = useRouter();
+const subscriptionStore = useSubscriptionStore();
+const bannerStyle = computed(() => {
+  const days = subscriptionStore.daysRemaining;
+
+  if (!days) return null;
+
+  if (days === 0) {
+    return {
+      bg: 'bg-red-50',
+      border: 'border-red-200',
+      icon: 'text-red-600',
+      text: 'text-red-900',
+      buttonBg: 'bg-red-600 hover:bg-red-700',
+    };
+  } else if (days <= 3) {
+    return {
+      bg: 'bg-orange-50',
+      border: 'border-orange-200',
+      icon: 'text-orange-600',
+      text: 'text-orange-900',
+      buttonBg: 'bg-orange-600 hover:bg-orange-700',
+    };
+  } else if (days <= 7) {
+    return {
+      bg: 'bg-yellow-50',
+      border: 'border-yellow-200',
+      icon: 'text-yellow-600',
+      text: 'text-yellow-900',
+      buttonBg: 'bg-yellow-600 hover:bg-yellow-700',
+    };
+  }
+
+  return null;
+});
+
+const message = computed(() => {
+  const days = subscriptionStore.daysRemaining;
+
+  if (!days) return '';
+
+  if (days === 0) {
+    return '您的試用期已到期，目前僅保留「商家資料展示」功能。';
+  } else if (days === 1) {
+    return '您的試用期即將於明天到期！';
+  } else {
+    return `您的試用期還剩 ${days} 天。`;
+  }
+});
+
+const shouldShowBanner = computed(() => {
+  return subscriptionStore.isTrial && bannerStyle.value !== null;
+});
+
+function goToUpgrade() {
+  router.push({ name: 'SubscriptionSelection' });
+}
+</script>
+
+<template>
+  <div
+    v-if="shouldShowBanner"
+    class="border-2 rounded-lg p-4 mb-6"
+    :class="[bannerStyle?.bg, bannerStyle?.border]"
+  >
+    <div class="flex items-start gap-3">
+      <!-- Icon -->
+      <span
+        class="material-symbols-outlined text-2xl mt-0.5"
+        :class="bannerStyle?.icon"
+      >
+        {{ subscriptionStore.isExpired ? 'error' : 'schedule' }}
+      </span>
+
+      <!-- Content -->
+      <div class="flex-1">
+        <p class="font-semibold mb-1" :class="bannerStyle?.text">
+          {{ subscriptionStore.isExpired ? '試用期已到期' : '試用期即將到期' }}
+        </p>
+        <p class="text-sm mb-3" :class="bannerStyle?.text">
+          {{ message }}
+          升級至永久會員，享有完整功能！
+        </p>
+
+        <!-- Action Button -->
+        <button
+          @click="goToUpgrade"
+          class="px-4 py-2 text-sm font-semibold text-white rounded-lg transition-colors"
+          :class="bannerStyle?.buttonBg"
+        >
+          立即升級
+        </button>
+      </div>
+
+      <div
+        v-if="!subscriptionStore.isExpired"
+        class="flex flex-col items-center justify-center min-w-[64px] h-16 rounded-lg bg-white/50"
+      >
+        <span class="text-2xl font-bold" :class="bannerStyle?.text">
+          {{ subscriptionStore.daysRemaining }}
+        </span>
+        <span class="text-xs" :class="bannerStyle?.text">
+          天
+        </span>
+      </div>
+    </div>
+  </div>
+</template>

--- a/frontend/src/stores/subscription.ts
+++ b/frontend/src/stores/subscription.ts
@@ -30,9 +30,10 @@ export const useSubscriptionStore = defineStore('subscription', () => {
 
     const today = new Date();
     const expiry = new Date(subscription.value.trialExpiryDate);
-    const diff = expiry.getTime() - today.getTime();
-    const days = Math.ceil(diff / (1000 * 60 * 60 * 24));
-
+    const startOfToday = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+    const startOfExpiryDay = new Date(expiry.getFullYear(), expiry.getMonth(), expiry.getDate());
+    const diffTime = startOfExpiryDay.getTime() - startOfToday.getTime();
+    const days = Math.round(diffTime / (1000 * 60 * 60 * 24));
     return days > 0 ? days : 0;
   });
 

--- a/frontend/src/stores/subscription.ts
+++ b/frontend/src/stores/subscription.ts
@@ -1,0 +1,175 @@
+import { defineStore } from 'pinia';
+import { ref, computed } from 'vue';
+
+export type PlanType = 'trial' | 'lifetime' | null;
+
+export type SubscriptionStatus = 'active' | 'expired' | 'cancelled';
+
+export interface Subscription {
+  id: string;
+  planType: PlanType;
+  status: SubscriptionStatus;
+  trialStartDate?: string;
+  trialExpiryDate?: string;
+  features: {
+    bookingManagement: boolean;
+    reviewSystem: boolean;
+    profileDisplay: boolean;
+  };
+}
+
+export const useSubscriptionStore = defineStore('subscription', () => {
+  const subscription = ref<Subscription | null>(null);
+  const isLoading = ref(false);
+  const error = ref<string | null>(null);
+
+
+  const daysRemaining = computed(() => {
+    if (!subscription.value?.trialExpiryDate) return null;
+    if (subscription.value.planType !== 'trial') return null;
+
+    const today = new Date();
+    const expiry = new Date(subscription.value.trialExpiryDate);
+    const diff = expiry.getTime() - today.getTime();
+    const days = Math.ceil(diff / (1000 * 60 * 60 * 24));
+
+    return days > 0 ? days : 0;
+  });
+
+
+  const isExpiringSoon = computed(() => {
+    if (!daysRemaining.value) return false;
+    return daysRemaining.value <= 7 && daysRemaining.value > 0;
+  });
+
+
+  const isExpired = computed(() => {
+    return daysRemaining.value === 0;
+  });
+
+
+  const isTrial = computed(() => {
+    return subscription.value?.planType === 'trial';
+  });
+
+
+  const isLifetime = computed(() => {
+    return subscription.value?.planType === 'lifetime';
+  });
+
+  // 格式化到期日期顯示
+  const expiryDisplayText = computed(() => {
+    if (!subscription.value?.trialExpiryDate) return '';
+    if (!isTrial.value) return '';
+
+    const expiryDate = new Date(subscription.value.trialExpiryDate);
+    const formatted = expiryDate.toLocaleDateString('zh-TW', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit'
+    });
+
+    if (daysRemaining.value === 0) {
+      return `試用已於 ${formatted} 到期`;
+    } else {
+      return `試用期限：${formatted}（剩餘 ${daysRemaining.value} 天）`;
+    }
+  });
+
+
+  async function fetchSubscription() {
+    isLoading.value = true;
+    error.value = null;
+
+    try {
+      const apiUrl = import.meta.env.VITE_API_URL || '';
+      const response = await fetch(`${apiUrl}/api/subscription/current`, {
+        credentials: 'include',
+        headers: {
+          'Content-Type': 'application/json',
+        }
+      });
+
+      const data = await response.json();
+
+      if (data.success && data.subscription) {
+        subscription.value = data.subscription;
+        return true;
+      } else {
+        subscription.value = null;
+        return false;
+      }
+    } catch (err) {
+      console.error('獲取訂閱資訊失敗:', err);
+      error.value = '無法載入訂閱資訊';
+      return false;
+    } finally {
+      isLoading.value = false;
+    }
+  }
+
+  async function activateTrial() {
+    isLoading.value = true;
+    error.value = null;
+
+    try {
+      const apiUrl = import.meta.env.VITE_API_URL || '';
+      const response = await fetch(`${apiUrl}/api/trial/activate`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: {
+          'Content-Type': 'application/json',
+        }
+      });
+
+      const data = await response.json();
+
+      if (data.success && data.subscription) {
+        subscription.value = data.subscription;
+        return { success: true };
+      } else {
+        error.value = data.message || '啟動試用失敗';
+        return { success: false, message: error.value };
+      }
+    } catch (err) {
+      console.error('啟動試用失敗:', err);
+      error.value = '網路錯誤，請稍後再試';
+      return { success: false, message: error.value };
+    } finally {
+      isLoading.value = false;
+    }
+  }
+
+  function hasFeature(feature: keyof Subscription['features']): boolean {
+    if (!subscription.value) return false;
+
+    if (isExpired.value && isTrial.value) {
+      return feature === 'profileDisplay';
+    }
+
+    return subscription.value.features[feature] || false;
+  }
+
+  function clearSubscription() {
+    subscription.value = null;
+    error.value = null;
+  }
+
+  return {
+    subscription,
+    isLoading,
+    error,
+
+    daysRemaining,
+    isExpiringSoon,
+    isExpired,
+    isTrial,
+    isLifetime,
+    expiryDisplayText,
+
+    fetchSubscription,
+    activateTrial,
+    hasFeature,
+    clearSubscription,
+  };
+});

--- a/frontend/src/views/Garage/SubscriptionSelection.vue
+++ b/frontend/src/views/Garage/SubscriptionSelection.vue
@@ -3,8 +3,10 @@ import { ref } from 'vue';
 import { useRouter } from 'vue-router';
 import PricingCard from '@/components/ui/PricingCard.vue';
 import PaymentDrawer from '@/components/payment/PaymentDrawer.vue';
+import { useSubscriptionStore } from '@/stores/subscription';
 
 const router = useRouter();
+const subscriptionStore = useSubscriptionStore();
 
 const pricingPlans = [
   {
@@ -67,16 +69,17 @@ async function handlePaymentMethodSelect(paymentMethod: 'oen' | 'linepay' | 'tri
 }
 
 async function activateFreeTrial() {
-  // TODO: 呼叫後端 API
-  // const response = await fetch('/api/trial/activate', { method: 'POST' });
+  const result = await subscriptionStore.activateTrial();
 
-  await new Promise(resolve => setTimeout(resolve, 1000));
-
-  closeDrawer();
-  router.push({
-    name: 'SubscriptionSuccess',
-    query: { type: 'trial' }
-  });
+  if (result.success) {
+    closeDrawer();
+    router.push({
+      name: 'SubscriptionSuccess',
+      query: { type: 'trial' }
+    });
+  } else {
+    alert(result.message || '啟動試用失敗，請稍後再試');
+  }
 }
 
 async function createPayment(plan: typeof pricingPlans[0], paymentMethod: 'oen' | 'linepay') {


### PR DESCRIPTION
已建立提醒的倒數，到時候要掛到維修廠後台的dashboard上

也還沒建立後端
```

  需要建立的 API：

  1. GET /api/subscription/current
    - 取得用戶當前訂閱資訊
    - 回傳試用開始日期和到期日期
  2. POST /api/trial/activate
    - 啟動試用方案
    - 自動計算到期日期（+30天）
```


<img width="1129" height="225" alt="截圖 2026-01-23 下午2 36 45" src="https://github.com/user-attachments/assets/a2bc8f9e-5635-4509-af25-aec0eb8ae93a" />
<img width="1116" height="206" alt="截圖 2026-01-23 下午2 36 51" src="https://github.com/user-attachments/assets/4ba2d937-c4cd-4350-b377-273d317b2834" />
<img width="1113" height="205" alt="截圖 2026-01-23 下午2 37 03" src="https://github.com/user-attachments/assets/efe3f668-e9ca-41a1-935a-f49240483b69" />
