### PR TITLE
#140 新版的搜尋結果頁layout & 詳細資訊頁修改前的前置

### DIFF
--- a/frontend/src/components/Search/DetailView.vue
+++ b/frontend/src/components/Search/DetailView.vue
@@ -1,14 +1,25 @@
 <script setup lang="ts">
 import { ref } from 'vue'
+import { useRouter } from 'vue-router'
 
+const router = useRouter()
 const isOpenMap = ref(false)
 const isOpenSurroundings = ref(false)
+
+const goBack = () => {
+  router.back()
+}
 </script>
 
 <template>
-  <div class="min-h-screen py-8 bg-[#FAF8F5] min-w-[450px]">
+  <div class="min-h-screen py-8 bg-[#FAF8F5] min-w-[375px]">
     <div class="max-w-6xl mx-auto px-4">
-      <div class="inline-flex items-center px-4 py-2 mb-4 text-sm text-gray-600 bg-white border border-gray-200 rounded-lg shadow-sm cursor-pointer hover:bg-gray-50 transition-colors">← 返回搜尋結果</div>
+      <button 
+        @click="goBack"
+        class="inline-flex items-center px-4 py-2 mb-4 text-sm text-gray-600 bg-white border border-gray-200 rounded-lg shadow-sm cursor-pointer hover:bg-gray-50 transition-colors"
+      >
+        ← 返回搜尋結果
+      </button>
       <div class="flex flex-col lg:flex-row gap-6 items-start">
         <div class="flex-1 w-full min-w-0 space-y-6">
           <section class="p-6 bg-white rounded-2xl shadow-sm">
@@ -52,11 +63,11 @@ const isOpenSurroundings = ref(false)
             <div class="mt-6">
               <h3 class="mb-2 font-medium text-gray-800">專修品牌</h3>
               <div class="flex flex-wrap gap-2">
-                <span class="px-16 py-1 text-sm bg-[#E8E3DB] rounded-full">Toyota</span>
-                <span class="px-16 py-1 text-sm bg-[#E8E3DB] rounded-full">Honda</span>
-                <span class="px-16 py-1 text-sm bg-[#E8E3DB] rounded-full">Nissan</span>
-                <span class="px-16 py-1 text-sm bg-[#E8E3DB] rounded-full">Mazda</span>
-                <span class="px-16 py-1 text-sm bg-[#E8E3DB] rounded-full">Lexus</span>
+                <span class="px-4 py-1 text-sm bg-[#E8E3DB] rounded-full">Toyota</span>
+                <span class="px-4 py-1 text-sm bg-[#E8E3DB] rounded-full">Honda</span>
+                <span class="px-4 py-1 text-sm bg-[#E8E3DB] rounded-full">Nissan</span>
+                <span class="px-4 py-1 text-sm bg-[#E8E3DB] rounded-full">Mazda</span>
+                <span class="px-4 py-1 text-sm bg-[#E8E3DB] rounded-full">Lexus</span>
               </div>
             </div>
             <div class="mt-6">
@@ -77,10 +88,7 @@ const isOpenSurroundings = ref(false)
               </div>
             </div>
             <button class="w-full mt-8 py-3 text-white bg-[#6B6B5C] rounded-xl transition hover:opacity-90">立即預約</button>
-
-            <!-- 手機版折疊選單 (接在立即預約下方) -->
             <div class="mt-6 space-y-4 lg:hidden">
-              <!-- 地圖折疊 -->
               <div class="border border-gray-200 rounded-xl overflow-hidden">
                 <button
                   @click="isOpenMap = !isOpenMap"
@@ -100,7 +108,6 @@ const isOpenSurroundings = ref(false)
                   <button class="mt-4 w-full py-2 text-sm text-[#6B6B5C] bg-[#FAF8F5] border border-[#E8E3DB] rounded-lg hover:bg-[#E8E3DB] transition">開啟 Google Maps 導航</button>
                 </div>
               </div>
-              <!-- 周邊休息折疊 -->
               <div class="border border-gray-200 rounded-xl overflow-hidden">
                 <button
                   @click="isOpenSurroundings = !isOpenSurroundings"
@@ -121,31 +128,13 @@ const isOpenSurroundings = ref(false)
                         <p class="text-xs text-gray-600 line-clamp-2">提供免費 WiFi 與插座，不限時。</p>
                       </div>
                     </div>
-                    <div class="flex gap-3 p-3 border border-gray-100 rounded-xl transition hover:bg-gray-50">
-                      <div class="flex items-center justify-center flex-shrink-0 w-10 h-10 text-xl bg-[#FAF8F5] rounded-lg">🏪</div>
-                      <div class="flex-1 min-w-0">
-                        <div class="flex items-center justify-between mb-1">
-                          <h4 class="text-sm font-medium text-gray-900 truncate">7-11 毛毛門市</h4>
-                          <span class="px-1.5 py-0.5 text-[10px] text-[#6B6B5C] bg-[#E8E3DB] rounded">步行 1 分鐘</span>
-                        </div>
-                        <p class="text-xs text-gray-600 line-clamp-2">店內設有寬敞用餐區與廁所。</p>
-                      </div>
-                    </div>
-                    <div class="flex gap-3 p-3 border border-gray-100 rounded-xl transition hover:bg-gray-50">
-                      <div class="flex items-center justify-center flex-shrink-0 w-10 h-10 text-xl bg-[#FAF8F5] rounded-lg">🌳</div>
-                      <div class="flex-1 min-w-0">
-                        <div class="flex items-center justify-between mb-1">
-                          <h4 class="text-sm font-medium text-gray-900 truncate">毛毛防災公園</h4>
-                          <span class="px-1.5 py-0.5 text-[10px] text-[#6B6B5C] bg-[#E8E3DB] rounded">步行 8 分鐘</span>
-                        </div>
-                        <p class="text-xs text-gray-600 line-clamp-2">天氣好時適合散步。</p>
-                      </div>
-                    </div>
                   </div>
                 </div>
               </div>
             </div>
           </section>
+          
+          <!-- 評價區塊 -->
           <section class="p-6 bg-white rounded-2xl shadow-sm">
             <div class="flex items-center gap-2 mb-6">
               <h3 class="font-medium text-gray-800">顧客評價</h3>
@@ -162,65 +151,14 @@ const isOpenSurroundings = ref(false)
                     </div>
                     <div class="text-yellow-400">★★★★★</div>
                   </div>
-                  <p class="mt-2 text-sm leading-relaxed text-gray-600">
-                    老闆技術很好，檢查很仔細，雖然是老車但也修得跟新的一樣！原本以為變速箱要大修，結果只是小零件問題，非常誠實的店家，大推！
-                  </p>
-                  <div class="mt-3 p-3 bg-[#F5F4F1] rounded-lg">
-                    <div class="flex items-center gap-2 mb-1">
-                      <span class="text-xs font-bold text-gray-700">店家回覆</span>
-                      <span class="text-[10px] text-gray-400">2025-12-27</span>
-                    </div>
-                    <p class="text-xs text-gray-600">
-                      感謝U先生的支持！能幫您省下不必要的罐罐是我們應該做的，老車好好保養還能開很久的，有問題隨時回來！
-                    </p>
-                  </div>
+                  <p class="mt-2 text-sm leading-relaxed text-gray-600">老闆技術很好，檢查很仔細！</p>
                 </div>
-              </div>
-              <div class="border-t border-gray-100"></div>
-              <div class="flex gap-4">
-                <div class="flex items-center justify-center flex-shrink-0 w-10 h-10 font-medium text-gray-600 bg-[#E8E3DB] rounded-full">D</div>
-                <div class="flex-1">
-                  <div class="flex items-center justify-between">
-                    <div class="flex gap-2 text-sm text-gray-700">
-                      <span class="font-medium">D貓貓</span>
-                      <span class="text-gray-400">2025-12-20</span>
-                    </div>
-                    <div class="text-yellow-400">★★★★★</div>
-                  </div>
-                  <p class="mt-2 text-sm leading-relaxed text-gray-600">
-                    冷氣突然不冷，跑了好幾家都說要換整組，這裡師傅幫我抓到是管路洩漏，補好灌冷媒就超級冷，省了一大筆錢！休息區還有路易莎咖啡可以喝，很貼心。
-                  </p>
-                  <div class="mt-3 p-3 bg-[#F5F4F1] rounded-lg">
-                    <div class="flex items-center gap-2 mb-1">
-                      <span class="text-xs font-bold text-gray-700">店家回覆</span>
-                      <span class="text-[10px] text-gray-400">2025-12-21</span>
-                    </div>
-                    <p class="text-xs text-gray-600">
-                      謝謝D小姐的肯定！夏天冷氣真的很重要，很高興能解決您的困擾。
-                    </p>
-                  </div>
-                </div>
-              </div>
-              <div class="border-t border-gray-100"></div>
-              <div class="flex gap-4">
-                <div class="flex items-center justify-center flex-shrink-0 w-10 h-10 font-medium text-white bg-[#6B6B5C] rounded-full">T</div>
-                <div class="flex-1">
-                  <div class="flex items-center justify-between">
-                    <div class="flex gap-2 text-sm text-gray-700">
-                      <span class="font-medium">T貓貓</span>
-                      <span class="text-gray-400">2025-12-15</span>
-                    </div>
-                    <div class="text-yellow-400">★★★★☆</div>
-                  </div>
-                  <p class="mt-2 text-sm leading-relaxed text-gray-600">
-                    定期保養速度很快，價格公道透明。唯一的缺點是假日人有點多，建議大家要提早預約才不會等太久。
-                  </p>
-                  </div>
               </div>
             </div>
-            <button class="w-full mt-6 py-2 text-sm text-gray-500 border border-gray-200 rounded-lg hover:bg-gray-50 transition">查看更多評論</button>
           </section>
         </div>
+
+        <!-- 側邊欄 (電腦版) -->
         <div class="w-full lg:w-[320px] flex-shrink-0 hidden lg:block">
           <div class="sticky top-8 space-y-6">
             <div class="p-6 bg-white rounded-2xl shadow-sm">
@@ -229,46 +167,9 @@ const isOpenSurroundings = ref(false)
                 <span class="text-4xl mb-2">🗺️</span>
                 <span class="text-sm">Google Map 載入中...</span>
               </div>
-              <div class="mt-4 text-sm text-gray-500">
-                <p>地址：台北市咪咪毛毛區 123 號</p>
-              </div>
+              <p class="mt-4 text-sm text-gray-500">地址：台北市咪咪毛毛區 123 號</p>
               <button class="mt-4 w-full py-2 text-sm text-[#6B6B5C] bg-[#FAF8F5] border border-[#E8E3DB] rounded-lg hover:bg-[#E8E3DB] transition">開啟 Google Maps 導航</button>
             </div>
-            <section class="p-6 bg-white rounded-2xl shadow-sm">
-              <h3 class="mb-4 font-medium text-gray-800">周邊休息地點</h3>
-              <div class="space-y-4">
-                <div class="flex gap-3 p-3 border border-gray-100 rounded-xl transition hover:bg-gray-50">
-                  <div class="flex items-center justify-center flex-shrink-0 w-10 h-10 text-xl bg-[#FAF8F5] rounded-lg">☕</div>
-                  <div class="flex-1 min-w-0">
-                    <div class="flex items-center justify-between mb-1">
-                      <h4 class="text-sm font-medium text-gray-900 truncate">路易莎咖啡 咪咪店</h4>
-                      <span class="px-1.5 py-0.5 text-[10px] text-[#6B6B5C] bg-[#E8E3DB] rounded">步行 3 分鐘</span>
-                    </div>
-                    <p class="text-xs text-gray-600 line-clamp-2">提供免費 WiFi 與插座，不限時。</p>
-                  </div>
-                </div>
-                <div class="flex gap-3 p-3 border border-gray-100 rounded-xl transition hover:bg-gray-50">
-                  <div class="flex items-center justify-center flex-shrink-0 w-10 h-10 text-xl bg-[#FAF8F5] rounded-lg">🏪</div>
-                  <div class="flex-1 min-w-0">
-                    <div class="flex items-center justify-between mb-1">
-                      <h4 class="text-sm font-medium text-gray-900 truncate">7-11 毛毛門市</h4>
-                      <span class="px-1.5 py-0.5 text-[10px] text-[#6B6B5C] bg-[#E8E3DB] rounded">步行 1 分鐘</span>
-                    </div>
-                    <p class="text-xs text-gray-600 line-clamp-2">店內設有寬敞用餐區與廁所。</p>
-                  </div>
-                </div>
-                <div class="flex gap-3 p-3 border border-gray-100 rounded-xl transition hover:bg-gray-50">
-                  <div class="flex items-center justify-center flex-shrink-0 w-10 h-10 text-xl bg-[#FAF8F5] rounded-lg">🌳</div>
-                  <div class="flex-1 min-w-0">
-                    <div class="flex items-center justify-between mb-1">
-                      <h4 class="text-sm font-medium text-gray-900 truncate">毛毛防災公園</h4>
-                      <span class="px-1.5 py-0.5 text-[10px] text-[#6B6B5C] bg-[#E8E3DB] rounded">步行 8 分鐘</span>
-                    </div>
-                    <p class="text-xs text-gray-600 line-clamp-2">天氣好時適合散步。</p>
-                  </div>
-                </div>
-              </div>
-            </section>
           </div>
         </div>
       </div>

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -38,6 +38,14 @@ const router = createRouter({
       },
     },
     {
+      path: '/search/:id',
+      name: 'ShopDetail',
+      component: () => import('@/components/Search/DetailView.vue'),
+      meta: {
+        title: '保養廠詳情 - carE',
+      },
+    },
+    {
       path: '/auth/callback',
       name: 'auth-callback',
       component: () => import('@/views/Auth/AuthCallback.vue'),

--- a/frontend/src/views/Search/SearchResults.vue
+++ b/frontend/src/views/Search/SearchResults.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue';
-import { useRoute } from 'vue-router'
+import { ref, computed, onMounted, watch } from 'vue';
+import { useRoute, useRouter } from 'vue-router'
 import ShopCard from '@/components/ui/ShopCard.vue';
 
 
@@ -8,7 +8,12 @@ const orderTitle = ref('排序');
 const filterTitle = ref('篩選');
 const sortBy = ref('rating');
 const route = useRoute()
+const router = useRouter()
 const filterBy = ref('all');
+
+// 分頁相關設定
+const currentPage = ref(Number(route.query.page) || 1);
+const itemsPerPage = 8; // 每頁顯示 8 筆 (一行4格 x 2行)
 
 interface ResultItem {
   image?: string;
@@ -23,6 +28,7 @@ interface ResultItem {
 
 const allShops = ref<ResultItem[]>([]);
 
+// 篩選與排序邏輯
 const results = computed(() => {
   let filtered = [...allShops.value];
   if (filterBy.value === 'nearby') {
@@ -49,7 +55,35 @@ const results = computed(() => {
   }
   return filtered;
 });
+
+// 分頁計算
+const paginatedResults = computed(() => {
+  const start = (currentPage.value - 1) * itemsPerPage;
+  const end = start + itemsPerPage;
+  return results.value.slice(start, end);
+});
+
+const totalPages = computed(() => Math.ceil(results.value.length / itemsPerPage));
 const resultsCount = computed(() => results.value.length);
+
+// 監聽篩選或排序改變，重置頁碼
+watch([sortBy, filterBy], () => {
+  updatePage(1);
+});
+
+// 監聽路由參數變化（處理瀏覽器上一頁/下一頁）
+watch(() => route.query.page, (newPage) => {
+  currentPage.value = Number(newPage) || 1;
+});
+
+const updatePage = (page: number) => {
+  if (page >= 1 && page <= totalPages.value) {
+    router.push({
+      query: { ...route.query, page: page.toString() }
+    });
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  }
+};
 
 const fetchShops = async () => {
   try {
@@ -60,11 +94,8 @@ const fetchShops = async () => {
       service: route.query.service
     }
 
-    console.log('搜尋參數:', searchParams)
-
-    // 暫時使用 Mock Data (資料庫尚未建立時測試用)
-    // TODO: 資料庫建立後改用真實 API
-    allShops.value = [
+    // 擴充 Mock Data 以測試分頁 (12筆)
+    const mockData: ResultItem[] = [
       {
         id: 1,
         name: '匠心汽車維修中心',
@@ -95,20 +126,99 @@ const fetchShops = async () => {
         services: ['專業診斷', '原廠配件', '精密維修', '性能升級', '保養套餐', '質保服務'],
         image: 'https://picsum.photos/300/200?random=3',
       },
-    ]
+      {
+        id: 4,
+        name: '極速維修中心',
+        score: 4.5,
+        distance: 0.8,
+        reviewCount: 200,
+        brands: ['Tesla', 'BMW', 'Benz'],
+        services: ['電池檢測', '馬達維修', '軟體更新', '底盤強化'],
+        image: 'https://picsum.photos/300/200?random=4',
+      },
+      {
+        id: 5,
+        name: '安心汽修廠',
+        score: 4.2,
+        distance: 5.1,
+        reviewCount: 30,
+        brands: ['Nissan', 'Mitsubishi', 'Ford'],
+        services: ['快速保養', '輪胎定位', '鈑金烤漆'],
+        image: 'https://picsum.photos/300/200?random=5',
+      },
+      {
+        id: 6,
+        name: '城市車庫',
+        score: 3.8,
+        distance: 1.5,
+        reviewCount: 65,
+        brands: ['Honda', 'Toyota'],
+        services: ['引擎調校', '冷氣保養', '皮帶更換'],
+        image: 'https://picsum.photos/300/200?random=6',
+      },
+      {
+        id: 7,
+        name: '老張修車行',
+        score: 4.8,
+        distance: 0.5,
+        reviewCount: 300,
+        brands: ['Toyota', 'Nissan', 'Lexus'],
+        services: ['老車翻新', '疑難雜症', '定期檢查'],
+        image: 'https://picsum.photos/300/200?random=7',
+      },
+      {
+        id: 8,
+        name: '德系精修館',
+        score: 5,
+        distance: 10.2,
+        reviewCount: 15,
+        brands: ['Porsche', 'Audi', 'VW'],
+        services: ['動力改裝', '電腦編程', '賽道設定'],
+        image: 'https://picsum.photos/300/200?random=8',
+      },
+      {
+        id: 9,
+        name: '未來汽車工坊',
+        score: 4.1,
+        distance: 6.7,
+        reviewCount: 45,
+        brands: ['Hyundai', 'Kia'],
+        services: ['混合動力維修', '高壓電系統', '電池更換'],
+        image: 'https://picsum.photos/300/200?random=9',
+      },
+      {
+        id: 10,
+        name: '山路救援站',
+        score: 4.9,
+        distance: 15.3,
+        reviewCount: 10,
+        brands: ['Subaru', 'Suzuki'],
+        services: ['越野改裝', '底盤升高', '絞盤安裝'],
+        image: 'https://picsum.photos/300/200?random=10',
+      },
+      {
+        id: 11,
+        name: '濱海保養所',
+        score: 3.5,
+        distance: 20.0,
+        reviewCount: 5,
+        brands: ['Luxgen', 'Ford'],
+        services: ['防鏽處理', '底盤防護', '基本保養'],
+        image: 'https://picsum.photos/300/200?random=11',
+      },
+       {
+        id: 12,
+        name: '優質輪胎館',
+        score: 4.6,
+        distance: 1.8,
+        reviewCount: 180,
+        brands: ['Michelin', 'Bridgestone', 'Continental'],
+        services: ['輪胎更換', '四輪定位', '補胎服務'],
+        image: 'https://picsum.photos/300/200?random=12',
+      },
+    ];
 
-    // 真實 API 呼叫 (資料庫建立後使用)
-    /*
-    const params = new URLSearchParams(searchParams as Record<string, string>)
-    const response = await fetch(`/api/search?${params.toString()}`)
-
-    if (!response.ok) {
-      throw new Error('搜尋失敗')
-    }
-
-    const data = await response.json()
-    allShops.value = data.data || []
-    */
+    allShops.value = mockData;
 
   } catch (err) {
     console.log('沒有符合資料的結果:', err)
@@ -117,9 +227,7 @@ const fetchShops = async () => {
 };
 
 const handleViewDetail = (shopId: number) => {
-  console.log('使用者要查看商店詳細，ID:', shopId);
-  // TODO: 之後這裡會接路由跳轉
-  alert(`查看商店 ID: ${shopId} 的詳細資料`);
+  router.push(`/search/${shopId}`);
 };
 
 onMounted(() => {
@@ -173,20 +281,69 @@ onMounted(() => {
     </div>
   </section>
 
-  <section class="pt-5 bg-[#f5f1ed] pb-10 min-h-[60vh]">
-    <div class="container mx-auto">
-      <div v-if="!resultsCount" class="text-center py-10">
+  <section class="pt-5 bg-[#f5f1ed] pb-20 min-h-[60vh]">
+    <div class="container mx-auto px-4">
+      <div v-if="!resultsCount" class="text-center py-20">
         <p class="text-[#4a4a43] text-lg">查無相關結果</p>
         <p class="text-[#4a4a43] text-sm mt-2">請嘗試調整篩選條件</p>
       </div>
-      <div v-else class="grid grid-cols-1 mx-2 md:grid-cols-2 mx-2 gap-3 lg:grid-cols-3 gap-5">
-        <ShopCard
-          v-for="shop in results"
-          :key="shop.id"
-          :shop="shop"
-          @view-detail="handleViewDetail"
-        />
+      
+      <div v-else>
+        <!-- 一行四格 (lg:grid-cols-4) -->
+        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+          <ShopCard
+            v-for="shop in paginatedResults"
+            :key="shop.id"
+            :shop="shop"
+            @view-detail="handleViewDetail"
+          />
+        </div>
+
+        <!-- 分頁 UI -->
+        <div v-if="totalPages > 1" class="flex justify-center items-center mt-12 gap-3">
+          <button
+            @click="updatePage(currentPage - 1)"
+            :disabled="currentPage === 1"
+            class="flex items-center justify-center w-10 h-10 rounded-full border border-[#DBCEBD] bg-white text-[#4a4a43] hover:bg-[#8b7d6b] hover:text-white disabled:opacity-30 disabled:cursor-not-allowed transition-all"
+            aria-label="上一頁"
+          >
+            <span class="material-symbols-outlined text-sm">chevron_left</span>
+          </button>
+          
+          <div class="flex gap-2">
+            <button
+              v-for="page in totalPages"
+              :key="page"
+              @click="updatePage(page)"
+              :class="[
+                'w-10 h-10 rounded-full border transition-all font-medium text-sm',
+                currentPage === page
+                  ? 'bg-[#8b7d6b] text-white border-[#8b7d6b] shadow-sm' 
+                  : 'bg-white text-[#4a4a43] border-[#DBCEBD] hover:border-[#8b7d6b] hover:text-[#8b7d6b]'
+              ]"
+            >
+              {{ page }}
+            </button>
+          </div>
+
+          <button
+            @click="updatePage(currentPage + 1)"
+            :disabled="currentPage === totalPages"
+            class="flex items-center justify-center w-10 h-10 rounded-full border border-[#DBCEBD] bg-white text-[#4a4a43] hover:bg-[#8b7d6b] hover:text-white disabled:opacity-30 disabled:cursor-not-allowed transition-all"
+            aria-label="下一頁"
+          >
+            <span class="material-symbols-outlined text-sm">chevron_right</span>
+          </button>
+        </div>
       </div>
     </div>
   </section>
 </template>
+
+<style scoped>
+/* 確保箭頭圖示垂直居中 */
+.material-symbols-outlined {
+  font-size: 20px;
+  line-height: 1;
+}
+</style>


### PR DESCRIPTION
Fixes #140
### 新版的搜尋結果頁layout & 詳細資訊頁修改前的前置 
> 注意: 
搜尋頁面以及詳細資訊頁面在新的切版會有breaking change，缺少頁面區塊為正常現象。

### 更動的檔案
`SearchResults.vue` - 改為一行4格，總共兩行，並且新增了頁碼以及切換頁面的功能。
`DetailView.vue` - 休息處區塊先拔掉，這個頁面正在配合後端做調整。
`index.ts` - 佔位路由的串接。

在最開始專案規劃就已經討論過這兩個功能不僅是相扣一起，相比其他頁面也幾乎全是後端工程，是整個專案難度相對困難的部分，不過當時的進度只能先切版確認，這會在今天後端建設與資料庫接上後整個重製。

<img width="1072" height="988" alt="image" src="https://github.com/user-attachments/assets/16260e6e-88fd-48ba-8592-7c8810aa216b" />

<img width="1596" height="1196" alt="image" src="https://github.com/user-attachments/assets/15d8374e-7b25-4320-910d-496a93c17242" />
