### PR TITLE
#173 搜尋結過頁面與維修廠詳細資訊的後端架設

### DIFF
--- a/frontend/src/components/Home/HomeSearchBar.vue
+++ b/frontend/src/components/Home/HomeSearchBar.vue
@@ -60,8 +60,6 @@ const handleSubmit = (e: Event) => {
   const brand = formData.get('brand') as string
   const repair = formData.get('repair') as string
 
-  console.log('原始表單資料:', { city, district, brand, repair })
-
   if (!city) {
     alert('請至少選擇縣市')
     return
@@ -77,8 +75,6 @@ const handleSubmit = (e: Event) => {
 
   if (brand) searchParams.brand = brand
   if (repair) searchParams.service = repair
-
-  console.log('搜尋參數:', searchParams)
 
   router.push({
     name: 'SearchResults',

--- a/frontend/src/components/Home/HomeSearchBar.vue
+++ b/frontend/src/components/Home/HomeSearchBar.vue
@@ -37,12 +37,10 @@ onMounted(() => {
         onChange: (data: any) => {
           selectedCity.value = data.county
           selectedDistrict.value = data.district
-          console.log('當前選擇:', selectedCity.value, selectedDistrict.value)
         }
       } as any)
-      console.log('✅ 縣市選擇器初始化成功')
     } catch (error) {
-      console.error('❌ 縣市選擇器初始化失敗:', error)
+      console.error('縣市選擇器初始化失敗:', error)
     }
   }
 })
@@ -79,8 +77,6 @@ const handleSubmit = (e: Event) => {
   router.push({
     name: 'SearchResults',
     query: searchParams
-  }).catch(err => {
-    console.error('路由錯誤:', err)
   })
 }
 </script>

--- a/frontend/src/components/Home/HomeSearchBar.vue
+++ b/frontend/src/components/Home/HomeSearchBar.vue
@@ -62,14 +62,17 @@ const handleSubmit = (e: Event) => {
 
   console.log('原始表單資料:', { city, district, brand, repair })
 
-  if (!city || !district) {
-    alert('請選擇縣市和行政區')
+  if (!city) {
+    alert('請至少選擇縣市')
     return
   }
 
   const searchParams: Record<string, string> = {
-    city: city,
-    district: district
+    city: city
+  }
+
+  if (district) {
+    searchParams.district = district
   }
 
   if (brand) searchParams.brand = brand

--- a/frontend/src/components/Search/DetailView.vue
+++ b/frontend/src/components/Search/DetailView.vue
@@ -1,43 +1,175 @@
 <script setup lang="ts">
-import { ref } from 'vue'
-import { useRouter } from 'vue-router'
+import { ref, onMounted, computed } from 'vue'
+import { useRouter, useRoute } from 'vue-router'
+import { supabase } from '@/lib/supabase'
+import { calculateDistance, DEFAULT_LOCATION } from '@/utils/distance'
+import type { GarageDetail } from '@/types/database'
 
 const router = useRouter()
+const route = useRoute()
 const isOpenMap = ref(false)
 const isOpenSurroundings = ref(false)
+
+// 資料狀態
+const garage = ref<GarageDetail | null>(null)
+const loading = ref(false)
+const error = ref<string | null>(null)
+
+// 評分星星顯示
+const ratingStars = computed(() => {
+  if (!garage.value) return '☆☆☆☆☆'
+  const fullStars = Math.floor(garage.value.score)
+  const emptyStars = 5 - fullStars
+  return '★'.repeat(fullStars) + '☆'.repeat(emptyStars)
+})
+
+// 取得保養廠詳細資訊
+const fetchGarageDetail = async () => {
+  loading.value = true
+  error.value = null
+
+  try {
+    const garageId = Number(route.params.id)
+
+    if (!garageId || isNaN(garageId)) {
+      throw new Error('無效的保養廠 ID')
+    }
+
+    // 查詢保養廠資料（包含關聯的品牌和服務）
+    const { data, error: fetchError } = await supabase
+      .from('garages')
+      .select(`
+        *,
+        garage_brands (
+          brands (
+            brand_zh,
+            brand_en
+          )
+        ),
+        garage_services (
+          services (
+            name,
+            category
+          )
+        )
+      `)
+      .eq('id', garageId)
+      .single()
+
+    if (fetchError) {
+      throw fetchError
+    }
+
+    if (!data) {
+      throw new Error('找不到該保養廠')
+    }
+
+    // 計算距離
+    const userLocation = { lat: DEFAULT_LOCATION.lat, lng: DEFAULT_LOCATION.lng }
+    const distance = data.lat && data.lng
+      ? calculateDistance(userLocation.lat, userLocation.lng, data.lat, data.lng)
+      : 0
+
+    // 提取品牌名稱 - 處理可能為 null 的情況
+    const brands = (data.garage_brands || [])
+      .map((gb: any) => gb.brands?.brand_zh)
+      .filter((brand: any): brand is string => brand !== null && brand !== undefined)
+
+    // 提取服務項目名稱 - 處理可能為 null 的情況
+    const services = (data.garage_services || [])
+      .map((gs: any) => gs.services?.name)
+      .filter((service: any): service is string => service !== null && service !== undefined)
+
+    // 轉換為前端格式
+    garage.value = {
+      id: data.id,
+      name: data.name,
+      city: data.city,
+      district: data.district,
+      address: data.address,
+      lat: data.lat,
+      lng: data.lng,
+      score: data.rating ?? 0,
+      distance,
+      reviewCount: data.review_count ?? 0,
+      brands,
+      services,
+      image: data.image_url ?? undefined,
+      phone: data.phone ?? undefined,
+      ownerName: data.garage_owner_name ?? data.garage_owner ?? undefined,
+      operatingHours: data.operating_hours ?? undefined,
+    }
+
+  } catch (err) {
+    console.error('查詢保養廠失敗:', err)
+    error.value = err instanceof Error ? err.message : '查詢失敗，請稍後再試'
+    garage.value = null
+  } finally {
+    loading.value = false
+  }
+}
 
 const goBack = () => {
   router.back()
 }
+
+onMounted(() => {
+  fetchGarageDetail()
+})
 </script>
 
 <template>
   <div class="min-h-screen py-8 bg-[#FAF8F5] min-w-[375px]">
     <div class="max-w-6xl mx-auto px-4">
-      <button 
+      <button
         @click="goBack"
         class="inline-flex items-center px-4 py-2 mb-4 text-sm text-gray-600 bg-white border border-gray-200 rounded-lg shadow-sm cursor-pointer hover:bg-gray-50 transition-colors"
       >
         ← 返回搜尋結果
       </button>
+
+      <!-- Loading 狀態 -->
+      <div v-if="loading" class="text-center py-20">
+        <div class="inline-block animate-spin rounded-full h-12 w-12 border-4 border-[#8b7d6b] border-t-transparent"></div>
+        <p class="text-[#4a4a43] text-lg mt-4">載入中...</p>
+      </div>
+
+      <!-- 錯誤狀態 -->
+      <div v-else-if="error" class="max-w-md mx-auto mt-10 p-6 bg-red-50 border border-red-200 rounded-lg">
+        <p class="text-red-600 text-lg font-medium">{{ error }}</p>
+        <button
+          @click="fetchGarageDetail"
+          class="mt-4 px-4 py-2 text-sm text-white bg-red-600 rounded-lg hover:bg-red-700"
+        >
+          重新載入
+        </button>
+      </div>
+
+      <!-- 查無資料 -->
+      <div v-else-if="!garage" class="text-center py-20">
+        <p class="text-[#4a4a43] text-lg">找不到該保養廠</p>
+      </div>
+
+      <!-- 保養廠詳細資料 -->
+      <div v-else>
       <div class="flex flex-col lg:flex-row gap-6 items-start">
         <div class="flex-1 w-full min-w-0 space-y-6">
           <section class="p-6 bg-white rounded-2xl shadow-sm">
             <div class="flex items-start justify-between">
               <div class="flex items-end gap-3">
-                <h1 class="text-xl font-semibold text-gray-900">匠心汽車維修中心</h1>
-                <span class="text-xs text-gray-500 mb-1">台北市咪咪毛毛區 123 號</span>
+                <h1 class="text-xl font-semibold text-gray-900">{{ garage.name }}</h1>
+                <span class="text-xs text-gray-500 mb-1">{{ garage.city }}{{ garage.district }} {{ garage.address }}</span>
               </div>
-              <div class="text-yellow-400">★★★★★</div>
+              <div class="text-yellow-400">{{ ratingStars }}</div>
             </div>
             <div class="mt-4 space-y-2 text-sm text-gray-600">
-              <div class="flex items-center gap-2">
+              <div v-if="garage.ownerName" class="flex items-center gap-2">
                 <span>店長姓名:</span>
-                <span>陳貓貓</span>
+                <span>{{ garage.ownerName }}</span>
               </div>
-              <div class="flex items-center gap-2">
+              <div v-if="garage.phone" class="flex items-center gap-2">
                 <span>聯絡電話:</span>
-                <span>(02) 2345-6789</span>
+                <span>{{ garage.phone }}</span>
               </div>
             </div>
             <div class="mt-6">
@@ -60,30 +192,30 @@ const goBack = () => {
                 </div>
               </div>
             </div>
-            <div class="mt-6">
+            <div class="mt-6" v-if="garage.brands.length > 0">
               <h3 class="mb-2 font-medium text-gray-800">專修品牌</h3>
               <div class="flex flex-wrap gap-2">
-                <span class="px-4 py-1 text-sm bg-[#E8E3DB] rounded-full">Toyota</span>
-                <span class="px-4 py-1 text-sm bg-[#E8E3DB] rounded-full">Honda</span>
-                <span class="px-4 py-1 text-sm bg-[#E8E3DB] rounded-full">Nissan</span>
-                <span class="px-4 py-1 text-sm bg-[#E8E3DB] rounded-full">Mazda</span>
-                <span class="px-4 py-1 text-sm bg-[#E8E3DB] rounded-full">Lexus</span>
+                <span
+                  v-for="brand in garage.brands"
+                  :key="brand"
+                  class="px-4 py-1 text-sm bg-[#E8E3DB] rounded-full"
+                >
+                  {{ brand }}
+                </span>
               </div>
             </div>
-            <div class="mt-6">
+            <div class="mt-6" v-if="garage.services.length > 0">
               <h3 class="mb-2 font-medium text-gray-800">服務項目</h3>
               <div class="flex flex-row gap-8 text-sm text-gray-700 sm:gap-12">
                 <ul class="pl-4 space-y-1 list-disc">
-                  <li>定期保養</li>
-                  <li>變速箱維修</li>
-                  <li>冷氣系統</li>
-                  <li>鈑金烤漆</li>
+                  <li v-for="(service, index) in garage.services" :key="service" v-show="index % 2 === 0">
+                    {{ service }}
+                  </li>
                 </ul>
                 <ul class="pl-4 space-y-1 list-disc">
-                  <li>引擎維修</li>
-                  <li>煞車系統</li>
-                  <li>電路系統</li>
-                  <li>輪胎更換</li>
+                  <li v-for="(service, index) in garage.services" :key="service" v-show="index % 2 === 1">
+                    {{ service }}
+                  </li>
                 </ul>
               </div>
             </div>
@@ -103,9 +235,14 @@ const goBack = () => {
                     <span class="text-sm">Google Map 載入中...</span>
                   </div>
                   <div class="mt-4 text-sm text-gray-500">
-                    <p>地址：台北市咪咪毛毛區 123 號</p>
+                    <p>地址：{{ garage.city }}{{ garage.district }} {{ garage.address }}</p>
                   </div>
-                  <button class="mt-4 w-full py-2 text-sm text-[#6B6B5C] bg-[#FAF8F5] border border-[#E8E3DB] rounded-lg hover:bg-[#E8E3DB] transition">開啟 Google Maps 導航</button>
+                  <button
+                    @click="window.open(`https://www.google.com/maps/search/?api=1&query=${garage.lat},${garage.lng}`, '_blank')"
+                    class="mt-4 w-full py-2 text-sm text-[#6B6B5C] bg-[#FAF8F5] border border-[#E8E3DB] rounded-lg hover:bg-[#E8E3DB] transition"
+                  >
+                    開啟 Google Maps 導航
+                  </button>
                 </div>
               </div>
               <div class="border border-gray-200 rounded-xl overflow-hidden">
@@ -167,12 +304,19 @@ const goBack = () => {
                 <span class="text-4xl mb-2">🗺️</span>
                 <span class="text-sm">Google Map 載入中...</span>
               </div>
-              <p class="mt-4 text-sm text-gray-500">地址：台北市咪咪毛毛區 123 號</p>
-              <button class="mt-4 w-full py-2 text-sm text-[#6B6B5C] bg-[#FAF8F5] border border-[#E8E3DB] rounded-lg hover:bg-[#E8E3DB] transition">開啟 Google Maps 導航</button>
+              <p class="mt-4 text-sm text-gray-500">地址：{{ garage.city }}{{ garage.district }} {{ garage.address }}</p>
+              <button
+                @click="window.open(`https://www.google.com/maps/search/?api=1&query=${garage.lat},${garage.lng}`, '_blank')"
+                class="mt-4 w-full py-2 text-sm text-[#6B6B5C] bg-[#FAF8F5] border border-[#E8E3DB] rounded-lg hover:bg-[#E8E3DB] transition"
+              >
+                開啟 Google Maps 導航
+              </button>
             </div>
           </div>
         </div>
       </div>
+      </div>
+      <!-- End of v-else garage data -->
     </div>
   </div>
 </template>

--- a/frontend/src/components/ui/ShopCard.vue
+++ b/frontend/src/components/ui/ShopCard.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { computed } from 'vue';
 import Tag from './Tag.vue';
 import emptyStar from '@/assets/icons/emptyStar.svg';
 import filledStar from '@/assets/icons/fillStar.svg';
@@ -20,6 +21,12 @@ const props = defineProps<Props>();
 const emit = defineEmits<{
   viewDetail: [shopId: number];
 }>();
+
+// 限制顯示的品牌數量（最多3個）
+const displayedBrands = computed(() => props.shop.brands.slice(0, 3));
+
+// 限制顯示的服務數量（最多3個）
+const displayedServices = computed(() => props.shop.services.slice(0, 3));
 
 const handleViewDetail = () => {
   emit('viewDetail', props.shop.id);
@@ -49,16 +56,20 @@ const handleViewDetail = () => {
         <span class="material-symbols-outlined pr-2 mt-2">location_on</span>
         {{ shop.distance }} 公里
       </p>
-      <div class="flex flex-row flex-wrap justify-start items-center gap-2 my-5">
-        <Tag v-for="(brand, index) in shop.brands" :key="brand" :label="brand" variant="filled" />
+      <!-- 品牌標籤（最多3個） -->
+      <div v-if="displayedBrands.length > 0" class="flex flex-row flex-wrap justify-start items-center gap-2 my-3">
+        <Tag v-for="brand in displayedBrands" :key="brand" :label="brand" variant="filled" />
+        <span v-if="shop.brands.length > 3" class="text-xs text-[#8a8a7d]">+{{ shop.brands.length - 3 }}</span>
       </div>
-      <div class="flex flex-row flex-wrap justify-start items-center gap-2 my-5">
+      <!-- 服務標籤（最多3個） -->
+      <div v-if="displayedServices.length > 0" class="flex flex-row flex-wrap justify-start items-center gap-2 my-3">
         <Tag
-          v-for="(service, index) in shop.services"
+          v-for="service in displayedServices"
           :key="service"
           :label="service"
           variant="outlined"
         />
+        <span v-if="shop.services.length > 3" class="text-xs text-[#8a8a7d]">+{{ shop.services.length - 3 }}</span>
       </div>
       <button
         @click="handleViewDetail"

--- a/frontend/src/components/ui/ShopCard.vue
+++ b/frontend/src/components/ui/ShopCard.vue
@@ -14,6 +14,9 @@ interface Props {
     reviewCount: number;
     brands: string[];
     services: string[];
+    address: string;
+    city: string;
+    district: string;
   };
 }
 const props = defineProps<Props>();
@@ -41,28 +44,44 @@ const handleViewDetail = () => {
       class="w-full aspect-[3/2] object-cover"
     />
     <div class="px-5 py-3 text-[#4a4a43]">
-      <p class="my-2 font-semibold text-lg">{{ shop.name }}</p>
-      <p class="my-2">
-        <img
-          v-for="i in 5"
-          :key="i"
-          :src="i <= shop.score ? filledStar : emptyStar"
-          alt="star"
-          class="w-5 h-5 inline-block"
-        />
-      </p>
-      <span class="px-2 text-[#8a8a7d] text-xs">({{ shop.reviewCount }})</span>
-      <p class="flex flex-row justify-start items-center my-1">
-        <span class="material-symbols-outlined pr-2 mt-2">location_on</span>
-        {{ shop.distance }} 公里
-      </p>
+      <!-- 保養廠名稱 -->
+      <h3 class="my-2 font-semibold text-lg truncate" :title="shop.name">{{ shop.name }}</h3>
+
+      <!-- 評分和評論數 -->
+      <div class="flex items-center gap-2 my-2">
+        <div class="flex items-center">
+          <img
+            v-for="i in 5"
+            :key="i"
+            :src="i <= shop.score ? filledStar : emptyStar"
+            alt="star"
+            class="w-4 h-4"
+          />
+        </div>
+        <span class="text-[#8a8a7d] text-xs">({{ shop.reviewCount }})</span>
+      </div>
+
+      <!-- 距離 -->
+      <div class="flex items-center gap-1 text-sm my-1">
+        <span class="material-symbols-outlined text-base">location_on</span>
+        <span>{{ shop.distance }} 公里</span>
+      </div>
+
+      <!-- 地址 -->
+      <div class="flex items-start gap-1 text-xs text-[#6B6B5C] my-1">
+        <span class="material-symbols-outlined text-base flex-shrink-0">home</span>
+        <span class="line-clamp-1" :title="`${shop.city}${shop.district} ${shop.address}`">
+          {{ shop.city }}{{ shop.district }} {{ shop.address }}
+        </span>
+      </div>
       <!-- 品牌標籤（最多3個） -->
-      <div v-if="displayedBrands.length > 0" class="flex flex-row flex-wrap justify-start items-center gap-2 my-3">
+      <div v-if="displayedBrands.length > 0" class="flex flex-row flex-wrap justify-start items-center gap-2 mt-3 mb-2">
         <Tag v-for="brand in displayedBrands" :key="brand" :label="brand" variant="filled" />
         <span v-if="shop.brands.length > 3" class="text-xs text-[#8a8a7d]">+{{ shop.brands.length - 3 }}</span>
       </div>
+
       <!-- 服務標籤（最多3個） -->
-      <div v-if="displayedServices.length > 0" class="flex flex-row flex-wrap justify-start items-center gap-2 my-3">
+      <div v-if="displayedServices.length > 0" class="flex flex-row flex-wrap justify-start items-center gap-2 my-2">
         <Tag
           v-for="service in displayedServices"
           :key="service"
@@ -71,9 +90,11 @@ const handleViewDetail = () => {
         />
         <span v-if="shop.services.length > 3" class="text-xs text-[#8a8a7d]">+{{ shop.services.length - 3 }}</span>
       </div>
+
+      <!-- 查看詳細資料按鈕 -->
       <button
         @click="handleViewDetail"
-        class="w-full block p-3 bg-[#6B6B5C] text-[14px] text-white rounded-[8px] cursor-pointer hover:bg-[#5A5A4D] transition-colors"
+        class="w-full mt-3 p-3 bg-[#6B6B5C] text-[14px] text-white rounded-[8px] cursor-pointer hover:bg-[#5A5A4D] transition-colors"
       >
         查看詳細資料
       </button>

--- a/frontend/src/components/ui/ShopCard.vue
+++ b/frontend/src/components/ui/ShopCard.vue
@@ -27,7 +27,7 @@ const handleViewDetail = () => {
 </script>
 
 <template>
-  <div class="border border-[#DBCEBD] rounded-[5px] overflow-hidden hover:shadow-md duration-300 bg-white">
+  <div class="border border-[#D4CEC4] rounded-[5px] overflow-hidden hover:shadow-lg duration-300 bg-white">
     <img
       :src="shop.image || 'https://picsum.photos/300/200?random=1'"
       :alt="`${shop.name}環境圖片`"
@@ -62,7 +62,7 @@ const handleViewDetail = () => {
       </div>
       <button
         @click="handleViewDetail"
-        class="w-full block p-3 bg-[#8b7d6b] text-[14px] text-white rounded-[8px] cursor-pointer hover:bg-[#6d6250] transition-colors"
+        class="w-full block p-3 bg-[#6B6B5C] text-[14px] text-white rounded-[8px] cursor-pointer hover:bg-[#5A5A4D] transition-colors"
       >
         查看詳細資料
       </button>

--- a/frontend/src/components/ui/ShopCard.vue
+++ b/frontend/src/components/ui/ShopCard.vue
@@ -70,8 +70,8 @@ const handleViewDetail = () => {
       <!-- 地址 -->
       <div class="flex items-start gap-1 text-xs text-[#6B6B5C] my-1">
         <span class="material-symbols-outlined text-base flex-shrink-0">home</span>
-        <span class="line-clamp-1" :title="`${shop.city}${shop.district} ${shop.address}`">
-          {{ shop.city }}{{ shop.district }} {{ shop.address }}
+        <span class="line-clamp-1" :title="shop.address">
+          {{ shop.address }}
         </span>
       </div>
       <!-- 品牌標籤（最多3個） -->

--- a/frontend/src/components/ui/Tag.vue
+++ b/frontend/src/components/ui/Tag.vue
@@ -13,9 +13,9 @@ const tagClass = computed(() => {
   const baseClass = 'inline-block px-3 py-1 text-[14px] rounded-full';
 
   if (props.variant === 'filled') {
-    return `${baseClass} bg-[#8b7d6b] text-white`;
+    return `${baseClass} bg-[#6B6B5C] text-white`;
   } else {
-    return `${baseClass} bg-[#f5f1ed] text-[#8b7d6b] border border-[#8b7d6b]`;
+    return `${baseClass} bg-[#F5F2EE] text-[#6B6B5C] border border-[#6B6B5C]`;
   }
 });
 </script>

--- a/frontend/src/types/database.ts
+++ b/frontend/src/types/database.ts
@@ -1,0 +1,27 @@
+/**
+ * 資料庫型別定義
+ */
+
+// 前端使用的保養廠項目格式（SearchResults）
+export interface GarageItem {
+  id: number;
+  name: string;
+  score: number;
+  distance: number;
+  reviewCount: number;
+  brands: string[];
+  services: string[];
+  image?: string;
+}
+
+// 詳情頁使用的保養廠格式（DetailView）
+export interface GarageDetail extends GarageItem {
+  city: string;
+  district: string;
+  address: string;
+  lat: number;
+  lng: number;
+  phone?: string;
+  ownerName?: string;
+  operatingHours?: any;
+}

--- a/frontend/src/types/database.ts
+++ b/frontend/src/types/database.ts
@@ -12,6 +12,9 @@ export interface GarageItem {
   brands: string[];
   services: string[];
   image?: string;
+  address: string;
+  city: string;
+  district: string;
 }
 
 // 詳情頁使用的保養廠格式（DetailView）

--- a/frontend/src/utils/distance.ts
+++ b/frontend/src/utils/distance.ts
@@ -1,0 +1,87 @@
+/**
+ * 距離計算工具函數
+ * 使用 Haversine 公式計算兩個經緯度座標之間的距離
+ */
+
+/**
+ * 計算兩個經緯度座標之間的距離（公里）
+ */
+export function calculateDistance(
+  lat1: number,
+  lng1: number,
+  lat2: number,
+  lng2: number
+): number {
+  const R = 6371; // 地球半徑（公里）
+
+  const dLat = toRadians(lat2 - lat1);
+  const dLng = toRadians(lng2 - lng1);
+
+  const a =
+    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+    Math.cos(toRadians(lat1)) *
+      Math.cos(toRadians(lat2)) *
+      Math.sin(dLng / 2) *
+      Math.sin(dLng / 2);
+
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  const distance = R * c;
+
+  return Math.round(distance * 10) / 10; // 保留一位小數
+}
+
+/**
+ * 將角度轉換為弧度
+ */
+function toRadians(degrees: number): number {
+  return (degrees * Math.PI) / 180;
+}
+
+/**
+ * 取得使用者當前位置（經緯度）
+ */
+export function getUserLocation(): Promise<{ lat: number; lng: number }> {
+  return new Promise((resolve, reject) => {
+    if (!navigator.geolocation) {
+      reject(new Error('你的瀏覽器不支援定位功能'));
+      return;
+    }
+
+    navigator.geolocation.getCurrentPosition(
+      (position) => {
+        resolve({
+          lat: position.coords.latitude,
+          lng: position.coords.longitude,
+        });
+      },
+      (error) => {
+        let errorMessage = '無法取得位置';
+        switch (error.code) {
+          case error.PERMISSION_DENIED:
+            errorMessage = '使用者拒絕定位請求';
+            break;
+          case error.POSITION_UNAVAILABLE:
+            errorMessage = '位置資訊無法取得';
+            break;
+          case error.TIMEOUT:
+            errorMessage = '定位請求逾時';
+            break;
+        }
+        reject(new Error(errorMessage));
+      },
+      {
+        enableHighAccuracy: true,
+        timeout: 5000,
+        maximumAge: 0,
+      }
+    );
+  });
+}
+
+/**
+ * 預設的台北市中心座標（當無法取得使用者位置時使用）
+ */
+export const DEFAULT_LOCATION = {
+  lat: 25.0330,
+  lng: 121.5654,
+};

--- a/frontend/src/views/Search/SearchResults.vue
+++ b/frontend/src/views/Search/SearchResults.vue
@@ -1,7 +1,10 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, watch } from 'vue';
-import { useRoute, useRouter } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router';
 import ShopCard from '@/components/ui/ShopCard.vue';
+import { supabase } from '@/lib/supabase';
+import { calculateDistance, getUserLocation, DEFAULT_LOCATION } from '@/utils/distance';
+import type { GarageItem } from '@/types/database';
 
 
 const orderTitle = ref('排序');
@@ -15,18 +18,10 @@ const filterBy = ref('all');
 const currentPage = ref(Number(route.query.page) || 1);
 const itemsPerPage = 8; // 每頁顯示 8 筆 (一行4格 x 2行)
 
-interface ResultItem {
-  image?: string;
-  id: number;
-  name: string;
-  score: number;
-  distance: number;
-  reviewCount: number;
-  brands: string[];
-  services: string[];
-}
-
-const allShops = ref<ResultItem[]>([]);
+// 資料狀態
+const allShops = ref<GarageItem[]>([]);
+const loading = ref(false);
+const error = ref<string | null>(null);
 
 // 篩選與排序邏輯
 const results = computed(() => {
@@ -86,149 +81,122 @@ const updatePage = (page: number) => {
 };
 
 const fetchShops = async () => {
+  loading.value = true;
+  error.value = null;
+
   try {
+    // 取得搜尋參數，並將繁體「臺」轉換為簡體「台」以匹配資料庫
+    const normalizeCity = (city: string | undefined) => {
+      if (!city) return city;
+      return city.replace(/臺/g, '台');
+    };
+
     const searchParams = {
-      city: route.query.city,
-      district: route.query.district,
-      brand: route.query.brand,
-      service: route.query.service,
-      category: route.query.category
+      city: normalizeCity(route.query.city as string | undefined),
+      district: route.query.district as string | undefined,
+      brand: route.query.brand as string | undefined,
+      service: route.query.service as string | undefined,
+    };
+
+    // 取得使用者位置（用於計算距離）
+    let userLocation = { lat: DEFAULT_LOCATION.lat, lng: DEFAULT_LOCATION.lng };
+
+    // 建立 Supabase 查詢
+    let query = supabase
+      .from('garages')
+      .select(`
+        id,
+        name,
+        city,
+        district,
+        address,
+        lat,
+        lng,
+        rating,
+        review_count,
+        image_url,
+        garage_brands (
+          brands (
+            brand_zh,
+            brand_en
+          )
+        ),
+        garage_services (
+          services (
+            name,
+            category
+          )
+        )
+      `);
+
+    // 套用篩選條件
+    if (searchParams.city) {
+      query = query.eq('city', searchParams.city);
     }
 
-    // TODO: 未來串接真實後端 API 時使用這些參數
-    // const response = await fetch(`/api/search?${new URLSearchParams(searchParams).toString()}`)
-    // const data = await response.json()
-    // allShops.value = data
+    if (searchParams.district) {
+      query = query.eq('district', searchParams.district);
+    }
 
-    // 擴充 Mock Data 以測試分頁 (12筆)
-    const mockData: ResultItem[] = [
-      {
-        id: 1,
-        name: '匠心汽車維修中心',
-        score: 5,
-        distance: 1.2,
-        reviewCount: 120,
-        brands: ['Benz', 'BMW', '奧迪', '保時捷'],
-        services: ['保養維護', '故障維修', '年檢服務', '鈑金噴漆', '輪胎更換', '冷氣維修'],
-        image: 'https://picsum.photos/300/200?random=1',
-      },
-      {
-        id: 2,
-        name: '職人汽車保養廠',
-        score: 4,
-        distance: 2.5,
-        reviewCount: 85,
-        brands: ['豐田', '本田', 'Volvo', '馬自達'],
-        services: ['定期保養', '引擎維修', '變速箱維修', '煞車系統', '電路檢修', '冷氣維修'],
-        image: 'https://picsum.photos/300/200?random=2',
-      },
-      {
-        id: 3,
-        name: '專業汽車維修站',
-        score: 3,
-        distance: 3.8,
-        reviewCount: 50,
-        brands: ['福斯', '奧迪', '保時捷', 'BMW'],
-        services: ['專業診斷', '原廠配件', '精密維修', '性能升級', '保養套餐', '質保服務'],
-        image: 'https://picsum.photos/300/200?random=3',
-      },
-      {
-        id: 4,
-        name: '極速維修中心',
-        score: 4.5,
-        distance: 0.8,
-        reviewCount: 200,
-        brands: ['Tesla', 'BMW', 'Benz'],
-        services: ['電池檢測', '馬達維修', '軟體更新', '底盤強化'],
-        image: 'https://picsum.photos/300/200?random=4',
-      },
-      {
-        id: 5,
-        name: '安心汽修廠',
-        score: 4.2,
-        distance: 5.1,
-        reviewCount: 30,
-        brands: ['Nissan', 'Mitsubishi', 'Ford'],
-        services: ['快速保養', '輪胎定位', '鈑金烤漆'],
-        image: 'https://picsum.photos/300/200?random=5',
-      },
-      {
-        id: 6,
-        name: '城市車庫',
-        score: 3.8,
-        distance: 1.5,
-        reviewCount: 65,
-        brands: ['Honda', 'Toyota'],
-        services: ['引擎調校', '冷氣保養', '皮帶更換'],
-        image: 'https://picsum.photos/300/200?random=6',
-      },
-      {
-        id: 7,
-        name: '老張修車行',
-        score: 4.8,
-        distance: 0.5,
-        reviewCount: 300,
-        brands: ['Toyota', 'Nissan', 'Lexus'],
-        services: ['老車翻新', '疑難雜症', '定期檢查'],
-        image: 'https://picsum.photos/300/200?random=7',
-      },
-      {
-        id: 8,
-        name: '德系精修館',
-        score: 5,
-        distance: 10.2,
-        reviewCount: 15,
-        brands: ['Porsche', 'Audi', 'VW'],
-        services: ['動力改裝', '電腦編程', '賽道設定'],
-        image: 'https://picsum.photos/300/200?random=8',
-      },
-      {
-        id: 9,
-        name: '未來汽車工坊',
-        score: 4.1,
-        distance: 6.7,
-        reviewCount: 45,
-        brands: ['Hyundai', 'Kia'],
-        services: ['混合動力維修', '高壓電系統', '電池更換'],
-        image: 'https://picsum.photos/300/200?random=9',
-      },
-      {
-        id: 10,
-        name: '山路救援站',
-        score: 4.9,
-        distance: 15.3,
-        reviewCount: 10,
-        brands: ['Subaru', 'Suzuki'],
-        services: ['越野改裝', '底盤升高', '絞盤安裝'],
-        image: 'https://picsum.photos/300/200?random=10',
-      },
-      {
-        id: 11,
-        name: '濱海保養所',
-        score: 3.5,
-        distance: 20.0,
-        reviewCount: 5,
-        brands: ['Luxgen', 'Ford'],
-        services: ['防鏽處理', '底盤防護', '基本保養'],
-        image: 'https://picsum.photos/300/200?random=11',
-      },
-       {
-        id: 12,
-        name: '優質輪胎館',
-        score: 4.6,
-        distance: 1.8,
-        reviewCount: 180,
-        brands: ['Michelin', 'Bridgestone', 'Continental'],
-        services: ['輪胎更換', '四輪定位', '補胎服務'],
-        image: 'https://picsum.photos/300/200?random=12',
-      },
-    ];
+    // 品牌篩選
+    if (searchParams.brand) {
+      query = query.eq('garage_brands.brands.brand_zh', searchParams.brand);
+    }
 
-    allShops.value = mockData;
+    // 服務項目篩選
+    if (searchParams.service) {
+      query = query.eq('garage_services.services.name', searchParams.service);
+    }
+
+    const { data, error: fetchError } = await query;
+
+    if (fetchError) {
+      throw fetchError;
+    }
+
+    if (!data || data.length === 0) {
+      allShops.value = [];
+      return;
+    }
+
+    // 轉換資料格式並計算距離
+    const garages: GarageItem[] = data.map((garage: any) => {
+      // 計算距離
+      const distance =
+        garage.lat && garage.lng
+          ? calculateDistance(userLocation.lat, userLocation.lng, garage.lat, garage.lng)
+          : 0;
+
+      // 提取品牌名稱（中文）- 處理可能為 null 的情況
+      const brands = (garage.garage_brands || [])
+        .map((gb: any) => gb.brands?.brand_zh)
+        .filter((brand: any): brand is string => brand !== null && brand !== undefined);
+
+      // 提取服務項目名稱 - 處理可能為 null 的情況
+      const services = (garage.garage_services || [])
+        .map((gs: any) => gs.services?.name)
+        .filter((service: any): service is string => service !== null && service !== undefined);
+
+      return {
+        id: garage.id,
+        name: garage.name,
+        score: garage.rating ?? 0,
+        distance,
+        reviewCount: garage.review_count ?? 0,
+        brands,
+        services,
+        image: garage.image_url ?? undefined,
+      };
+    });
+
+    allShops.value = garages;
 
   } catch (err) {
-    console.log('沒有符合資料的結果:', err)
-    allShops.value = []
+    console.error('查詢保養廠失敗:', err);
+    error.value = err instanceof Error ? err.message : '查詢失敗，請稍後再試';
+    allShops.value = [];
+  } finally {
+    loading.value = false;
   }
 };
 
@@ -242,33 +210,33 @@ onMounted(() => {
 </script>
 
 <template>
-  <section class="pt-10 bg-[#f5f1ed]">
+  <section class="pt-10 bg-[#EBE8E3]">
     <div class="container mx-auto px-4">
       <div class="flex flex-col md:flex-row justify-between items-center gap-5">
-        <div class="w-full flex text-[#4a4a43] bg-[#ffffff] border border-[#DBCEBD] rounded-[5px]">
-          <label for="order" class="py-2 pl-3">{{ orderTitle }}：</label>
-          <select name="order" id="order" class="grow py-2 outline-none" v-model="sortBy">
+        <div class="w-full flex text-[#4a4a43] bg-[#ffffff] border-2 border-[#D4CEC4] rounded-[8px] hover:border-[#6B6B5C] transition-colors">
+          <label for="order" class="py-2 pl-3 font-medium">{{ orderTitle }}：</label>
+          <select name="order" id="order" class="grow py-2 pr-3 outline-none bg-transparent cursor-pointer" v-model="sortBy">
             <option value="rating" selected>依評價</option>
             <option value="distance">依距離</option>
             <option value="reviewCount">依評論數</option>
           </select>
         </div>
-        <div class="w-full flex text-[#4a4a43] bg-[#ffffff] border border-[#DBCEBD] rounded-[5px]">
-          <label for="filter" class="py-2 pl-3">{{ filterTitle }}：</label>
-          <select name="filter" id="filter" class="grow py-2 outline-none" v-model="filterBy">
+        <div class="w-full flex text-[#4a4a43] bg-[#ffffff] border-2 border-[#D4CEC4] rounded-[8px] hover:border-[#6B6B5C] transition-colors">
+          <label for="filter" class="py-2 pl-3 font-medium">{{ filterTitle }}：</label>
+          <select name="filter" id="filter" class="grow py-2 pr-3 outline-none bg-transparent cursor-pointer" v-model="filterBy">
             <option value="all" selected>全部</option>
             <option value="nearby">附近(3公里內)</option>
             <option value="ratingGood">評價 4 星以上</option>
           </select>
         </div>
       </div>
-      <div class="mt-4 text-[#4a4a43] text-sm" v-if="allShops.length > 0">
-        <p>
+      <div class="mt-4 text-[#6B6B5C] text-sm" v-if="allShops.length > 0">
+        <div class="bg-white/50 backdrop-blur-sm px-4 py-2 rounded-lg inline-block border border-[#D4CEC4]">
           <span class="font-semibold">顯示：</span>
           <span v-if="filterBy === 'all'">全部</span>
           <span v-else-if="filterBy === 'nearby'">附近（3公里內）</span>
           <span v-else-if="filterBy === 'ratingGood'">評價 4 星以上</span>
-          <span class="mx-2">|</span>
+          <span class="mx-2 text-[#D4CEC4]">|</span>
           <span class="font-semibold">排序：</span>
           <span v-if="filterBy === 'all'">
             <span v-if="sortBy === 'rating'">依評價</span>
@@ -281,19 +249,40 @@ onMounted(() => {
             <span v-else-if="sortBy === 'distance'">依距離</span>
             <span v-else>依評論數</span>
           </span>
-          <span class="ml-2 text-gray-600">(共 {{ resultsCount }} 間)</span>
-        </p>
+          <span class="ml-2 text-[#8a8a7d]">(共 {{ resultsCount }} 間)</span>
+        </div>
       </div>
     </div>
   </section>
 
-  <section class="pt-5 bg-[#f5f1ed] pb-20 min-h-[60vh]">
+  <section class="pt-5 bg-[#EBE8E3] pb-20 min-h-[60vh]">
     <div class="container mx-auto px-4">
-      <div v-if="!resultsCount" class="text-center py-20">
-        <p class="text-[#4a4a43] text-lg">查無相關結果</p>
-        <p class="text-[#4a4a43] text-sm mt-2">請嘗試調整篩選條件</p>
+      <!-- Loading 狀態 -->
+      <div v-if="loading" class="text-center py-20">
+        <div class="inline-block animate-spin rounded-full h-12 w-12 border-4 border-[#6B6B5C] border-t-transparent"></div>
+        <p class="text-[#4a4a43] text-lg mt-4">載入中...</p>
       </div>
-      
+
+      <!-- 錯誤狀態 -->
+      <div v-else-if="error" class="max-w-md mx-auto mt-10 p-6 bg-red-50 border border-red-200 rounded-lg">
+        <p class="text-red-600 text-lg font-medium">{{ error }}</p>
+        <button
+          @click="fetchShops"
+          class="mt-4 px-4 py-2 text-sm text-white bg-red-600 rounded-lg hover:bg-red-700"
+        >
+          重新載入
+        </button>
+      </div>
+
+      <!-- 查無結果 -->
+      <div v-else-if="!resultsCount && !loading" class="text-center py-20">
+        <div class="max-w-md mx-auto p-8 bg-white border-2 border-[#D4CEC4] rounded-lg">
+          <p class="text-[#6B6B5C] text-xl font-medium">查無相關結果</p>
+          <p class="text-[#8a8a7d] text-sm mt-3">請嘗試調整篩選條件或更換搜尋地區</p>
+        </div>
+      </div>
+
+      <!-- 搜尋結果 -->
       <div v-else>
         <!-- 一行四格 (lg:grid-cols-4) -->
         <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
@@ -310,22 +299,22 @@ onMounted(() => {
           <button
             @click="updatePage(currentPage - 1)"
             :disabled="currentPage === 1"
-            class="flex items-center justify-center w-10 h-10 rounded-full border border-[#DBCEBD] bg-white text-[#4a4a43] hover:bg-[#8b7d6b] hover:text-white disabled:opacity-30 disabled:cursor-not-allowed transition-all"
+            class="flex items-center justify-center w-10 h-10 rounded-full border-2 border-[#D4CEC4] bg-white text-[#4a4a43] hover:bg-[#6B6B5C] hover:text-white hover:border-[#6B6B5C] disabled:opacity-30 disabled:cursor-not-allowed transition-all"
             aria-label="上一頁"
           >
             <span class="material-symbols-outlined text-sm">chevron_left</span>
           </button>
-          
+
           <div class="flex gap-2">
             <button
               v-for="page in totalPages"
               :key="page"
               @click="updatePage(page)"
               :class="[
-                'w-10 h-10 rounded-full border transition-all font-medium text-sm',
+                'w-10 h-10 rounded-full border-2 transition-all font-medium text-sm',
                 currentPage === page
-                  ? 'bg-[#8b7d6b] text-white border-[#8b7d6b] shadow-sm' 
-                  : 'bg-white text-[#4a4a43] border-[#DBCEBD] hover:border-[#8b7d6b] hover:text-[#8b7d6b]'
+                  ? 'bg-[#6B6B5C] text-white border-[#6B6B5C] shadow-md'
+                  : 'bg-white text-[#4a4a43] border-[#D4CEC4] hover:border-[#6B6B5C] hover:text-[#6B6B5C]'
               ]"
             >
               {{ page }}
@@ -335,7 +324,7 @@ onMounted(() => {
           <button
             @click="updatePage(currentPage + 1)"
             :disabled="currentPage === totalPages"
-            class="flex items-center justify-center w-10 h-10 rounded-full border border-[#DBCEBD] bg-white text-[#4a4a43] hover:bg-[#8b7d6b] hover:text-white disabled:opacity-30 disabled:cursor-not-allowed transition-all"
+            class="flex items-center justify-center w-10 h-10 rounded-full border-2 border-[#D4CEC4] bg-white text-[#4a4a43] hover:bg-[#6B6B5C] hover:text-white hover:border-[#6B6B5C] disabled:opacity-30 disabled:cursor-not-allowed transition-all"
             aria-label="下一頁"
           >
             <span class="material-symbols-outlined text-sm">chevron_right</span>

--- a/frontend/src/views/Search/SearchResults.vue
+++ b/frontend/src/views/Search/SearchResults.vue
@@ -186,6 +186,9 @@ const fetchShops = async () => {
         brands,
         services,
         image: garage.image_url ?? undefined,
+        address: garage.address,
+        city: garage.city,
+        district: garage.district,
       };
     });
 

--- a/frontend/src/views/Search/SearchResults.vue
+++ b/frontend/src/views/Search/SearchResults.vue
@@ -160,29 +160,22 @@ const fetchShops = async () => {
     }
 
     // 轉換資料格式並計算距離
-    const garages: GarageItem[] = data.map((garage: any, index: number) => {
+    const garages: GarageItem[] = data.map((garage: any) => {
       // 計算距離
       const distance =
         garage.lat && garage.lng
           ? calculateDistance(userLocation.lat, userLocation.lng, garage.lat, garage.lng)
           : 0;
 
-      // 提取品牌名稱（中文）- 處理可能為 null 的情況
+      // 提取品牌名稱（中文）
       const brands = (garage.garage_brands || [])
         .map((gb: any) => gb.brands?.brand_zh)
         .filter((brand: any): brand is string => brand !== null && brand !== undefined);
 
-      // 提取服務項目名稱 - 處理可能為 null 的情況
+      // 提取服務項目名稱
       const services = (garage.garage_services || [])
         .map((gs: any) => gs.services?.name)
         .filter((service: any): service is string => service !== null && service !== undefined);
-
-      // 除錯：檢查第一筆資料
-      if (index === 0) {
-        console.log('📦 第一筆保養廠原始資料:', garage);
-        console.log('🏷️ 提取到的品牌:', brands);
-        console.log('🔧 提取到的服務:', services);
-      }
 
       return {
         id: garage.id,

--- a/frontend/src/views/Search/SearchResults.vue
+++ b/frontend/src/views/Search/SearchResults.vue
@@ -160,7 +160,7 @@ const fetchShops = async () => {
     }
 
     // 轉換資料格式並計算距離
-    const garages: GarageItem[] = data.map((garage: any) => {
+    const garages: GarageItem[] = data.map((garage: any, index: number) => {
       // 計算距離
       const distance =
         garage.lat && garage.lng
@@ -176,6 +176,13 @@ const fetchShops = async () => {
       const services = (garage.garage_services || [])
         .map((gs: any) => gs.services?.name)
         .filter((service: any): service is string => service !== null && service !== undefined);
+
+      // 除錯：檢查第一筆資料
+      if (index === 0) {
+        console.log('📦 第一筆保養廠原始資料:', garage);
+        console.log('🏷️ 提取到的品牌:', brands);
+        console.log('🔧 提取到的服務:', services);
+      }
 
       return {
         id: garage.id,


### PR DESCRIPTION
### 搜尋結過頁面與維修廠詳細資訊的後端架設
> 還是有要調整的地方，但因為這是對搜尋頁面做很大的調整更新，階段性內容理應當先推送上develop並部署測試。

<img width="1296" height="1104" alt="image" src="https://github.com/user-attachments/assets/997fbd11-6740-47dd-aa62-a2b559e48b26" />

### 功能
> 現在的搜尋頁面與Supabase有連線，在使用時請確定環境變數已經設置完成。
- 調整為不再需要行政區選擇也能搜尋。
- 每張卡片顯示的品牌與維修項目各顯示最多3個tag，3個以上目前
- 現在有頁碼可以切換。
- 每頁最多顯示8筆維修廠卡片。
- 每個卡片都可以進入到對應的維修廠詳細頁面。
(詳細頁面尚未完全改造，只有初步配合資料庫以及搜尋功能)

### TODO
- 現在搜尋加上車子品牌(或維修項目)無法正確篩選結果，卡片上的對應tag也會消失，這在下一次更新會修好。

### 此次更動的檔案
`HomeSearchBar.vue` - 把搜尋限制設定為只需要選縣市，過去需要加上行政區才能開始搜尋。
`DetailView.vue` - 可以正確的透過搜尋結果的卡片進入。
(裡面尚未有更進一步更新，但它已經與卡片還有資料庫連線上，是完全同步的資料)
`ShopCard.vue` - 雖然僅有切版調整，但它是搜尋結果的配對資料庫的重要附屬品。
`Tag.vue` - 與ShopCard相同，配合網頁主色副色調整視覺切版。
`database.ts` - 定義資料庫註冊的欄位。
`SearchResults.vue` - 幾乎重製，後端架設與Supabase連線同步資料，本次PR搜尋功能的核心元件。

---
電腦版(影片預覽)
https://github.com/user-attachments/assets/a7188fa2-24ce-4c39-a061-db6f8b6b9d3c

手機版(影片預覽)
https://github.com/user-attachments/assets/dcab01dd-39aa-4001-bece-e259ce3b4a5d

