### PR TITLE
#178 修正Navbar與其他功能頁面之間的間隔距離

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -6,7 +6,10 @@ import Footer from '@/components/layout/Footer.vue';
 <template>
   <div class="overflow-x-hidden">
     <HeaderNavbar />
-    <router-view />
+    <!-- 主內容區：添加 padding-top 避免被 fixed navbar 遮蓋 -->
+    <main class="pt-[60px] sm:pt-[70px]">
+      <router-view />
+    </main>
     <Footer />
   </div>
 </template>

--- a/frontend/src/views/Auth/AuthCallback.vue
+++ b/frontend/src/views/Auth/AuthCallback.vue
@@ -53,7 +53,7 @@ onMounted(async () => {
 </script>
 
 <template>
-  <div class="min-h-screen flex items-center justify-center bg-[#FAF8F5] px-4 pt-[60px] sm:pt-[70px]">
+  <div class="min-h-screen flex items-center justify-center bg-[#FAF8F5] px-4">
     <div class="max-w-md w-full bg-white rounded-2xl shadow-lg p-8 text-center">
       <div v-if="loading" class="py-8">
         <div class="flex items-center justify-center w-16 h-16 mx-auto mb-4 rounded-full bg-[#6B6B5C]/10">

--- a/frontend/src/views/Garage/GarageOnboarding.vue
+++ b/frontend/src/views/Garage/GarageOnboarding.vue
@@ -177,7 +177,7 @@ onUnmounted(() => {
 </script>
 
 <template>
-  <main class="relative min-h-screen bg-[#f5f4f0] pt-[60px] sm:pt-[70px]">
+  <main class="relative min-h-screen bg-[#f5f4f0]">
     <div class="w-full max-w-[800px] mx-auto px-4 sm:px-6 py-12">
       <div v-if="currentStep === 1" class="bg-white rounded-2xl shadow-lg p-6 sm:p-8">
         <h1 class="text-[28px] sm:text-[32px] font-bold text-[#4a4a43] mb-2 text-center">

--- a/frontend/src/views/Garage/JoinGarage.vue
+++ b/frontend/src/views/Garage/JoinGarage.vue
@@ -38,7 +38,7 @@ const navigateToOnboarding = () => {
 </script>
 
 <template>
-  <main class="relative mt-[60px] sm:mt-[70px]">
+  <div class="relative">
     <section
       class="text-center bg-[url(https://picsum.photos/id/133/1200/900)] bg-no-repeat bg-center bg-cover"
     >
@@ -159,6 +159,6 @@ const navigateToOnboarding = () => {
         </p>
       </div>
     </section>
-  </main>
+  </div>
 </template>
 

--- a/frontend/src/views/Garage/SubscriptionFailure.vue
+++ b/frontend/src/views/Garage/SubscriptionFailure.vue
@@ -27,7 +27,7 @@ onMounted(() => {
 </script>
 
 <template>
-  <main class="relative h-screen bg-[#f5f4f0] pt-[60px] sm:pt-[70px] overflow-hidden">
+  <main class="relative h-screen bg-[#f5f4f0] overflow-hidden">
     <div class="w-full max-w-[800px] h-full mx-auto px-6 sm:px-12 py-4 sm:py-6 flex flex-col">
       <!-- Failure Banner -->
       <div class="bg-gradient-to-r from-red-500 to-red-400 rounded-2xl shadow-lg p-4 sm:p-6 mb-3 text-white flex-shrink-0">

--- a/frontend/src/views/Garage/SubscriptionSelection.vue
+++ b/frontend/src/views/Garage/SubscriptionSelection.vue
@@ -119,7 +119,7 @@ function goBack() {
 </script>
 
 <template>
-  <main class="relative min-h-screen bg-[#f5f4f0] pt-[60px] sm:pt-[70px]">
+  <main class="relative min-h-screen bg-[#f5f4f0]">
     <div class="w-full max-w-[1200px] mx-auto px-4 sm:px-6 py-12">
       <div class="text-center mb-12">
         <h3 class="text-[32px] sm:text-[40px] font-bold text-[#4a4a43] mb-4">

--- a/frontend/src/views/Garage/SubscriptionSuccess.vue
+++ b/frontend/src/views/Garage/SubscriptionSuccess.vue
@@ -78,7 +78,7 @@ const goToDashboard = () => {
 </script>
 
 <template>
-  <main class="relative h-screen bg-[#f5f4f0] pt-[60px] sm:pt-[70px] overflow-hidden">
+  <main class="relative h-screen bg-[#f5f4f0] overflow-hidden">
     <div class="w-full max-w-[800px] h-full mx-auto px-6 sm:px-12 py-4 sm:py-6 flex flex-col">
       <!-- Success Banner -->
       <div class="bg-gradient-to-r from-[#70c287] to-[#8fd19f] rounded-2xl shadow-lg p-4 sm:p-6 mb-6 text-white flex-shrink-0">

--- a/frontend/src/views/Home/Home.vue
+++ b/frontend/src/views/Home/Home.vue
@@ -13,7 +13,7 @@ const handleCategorySearch = (category: string) => {
 </script>
 
 <template>
-  <main class="relative mt-[60px] sm:mt-[70px]">
+  <div class="relative">
     <section
       class="text-center bg-[url(https://picsum.photos/id/605/1200/900)] bg-no-repeat bg-center bg-cover"
     >
@@ -239,5 +239,5 @@ const handleCategorySearch = (category: string) => {
         </button>
       </a>
     </section>
-  </main>
+  </div>
 </template>

--- a/frontend/src/views/User/BookingList.vue
+++ b/frontend/src/views/User/BookingList.vue
@@ -5,7 +5,7 @@ const router = useRouter();
 </script>
 
 <template>
-  <div class="min-h-screen bg-[#f4f1eb] pt-[60px] sm:pt-[70px]">
+  <div class="min-h-screen bg-[#f4f1eb]">
     <header class="bg-[#f9f7f4] border-b border-[#e0dbd3]">
       <div class="max-w-5xl mx-auto px-6 py-5">
         <h1 class="text-[#4a4540] tracking-wide">預約紀錄</h1>

--- a/frontend/src/views/User/MaintenanceHistory.vue
+++ b/frontend/src/views/User/MaintenanceHistory.vue
@@ -5,7 +5,7 @@ const router = useRouter();
 </script>
 
 <template>
-  <div class="min-h-screen bg-[#f4f1eb] pt-[60px] sm:pt-[70px]">
+  <div class="min-h-screen bg-[#f4f1eb]">
     <header class="bg-[#f9f7f4] border-b border-[#e0dbd3]">
       <div class="max-w-5xl mx-auto px-6 py-5">
         <h1 class="text-[#4a4540] tracking-wide">維修歷史</h1>

--- a/frontend/src/views/User/UserDashboard.vue
+++ b/frontend/src/views/User/UserDashboard.vue
@@ -214,7 +214,7 @@ const handleSave = async () => {
 </script>
 
 <template>
-	<div class="min-h-screen bg-[#f4f1eb] pt-[60px] sm:pt-[70px]">
+	<div class="min-h-screen bg-[#f4f1eb]">
 		<header class="bg-[#f9f7f4] border-b border-[#e0dbd3]">
 			<div class="max-w-5xl mx-auto px-6 py-5">
 				<h1 class="text-[#4a4540] tracking-wide">會員中心</h1>


### PR DESCRIPTION
Fixes: #178 
現在所有頁面都統一由App.vue的main標籤提供navbar間距，不會再有雙重間距或覆蓋...等異常問題了。
> 可能還是會有遺漏的地方，日後會以hotfix形式推送補上。

### App.vue：
`src/App.vue` - 新增 pt-[60px] sm:pt-[70px] 到 main 標籤

### 頁面元件更改
全部都是移除` pt-[60px] sm:pt-[70px] `然後再做頁面對應的適配寫法，其他功能則沒有做任何更改。
- src/views/Home/Home.vue
- src/views/Garage/JoinGarage.vue
- src/views/Garage/SubscriptionFailure.vue
- src/views/Garage/SubscriptionSuccess.vue
- src/views/Garage/GarageOnboarding.vue
- src/views/Garage/SubscriptionSelection.vue
- src/views/User/BookingList.vue
- src/views/User/MaintenanceHistory.vue
- src/views/User/UserDashboard.vue
- src/views/Auth/AuthCallback.vue

<img width="1187" height="851" alt="image" src="https://github.com/user-attachments/assets/8967eb4e-3b52-41ed-9713-1d7e4abba64a" />