### PR TITLE
#24 第三方金流串接 

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -13,3 +13,7 @@ DB_PASSWORD=your_password_here
 # JWT 設定
 JWT_SECRET=your_secret_key_here
 JWT_EXPIRES_IN=
+
+# OEN Pay (應援金流) 設定
+OEN_MERCHANT_ID=your_merchant_id
+OEN_TOKEN=your_api_token

--- a/backend/index.js
+++ b/backend/index.js
@@ -2,6 +2,7 @@ import express from 'express'
 import cors from 'cors'
 import taxIdRoutes from './src/routes/taxId.js';
 import searchRoutes from './src/routes/search.js';
+import paymentRoutes from './src/routes/payment.js';
 import 'dotenv/config'
 
 
@@ -12,12 +13,11 @@ const allowedOrigins = [
   'http://localhost:5173',
   'http://localhost:5174',
   'https://care-f.zeabur.app',
-  process.env.FRONTEND_URL, // 額外的自訂網域
-].filter(Boolean); // 過濾掉 undefined
+  process.env.FRONTEND_URL, 
+].filter(Boolean); 
 
 const corsOptions = {
   origin: (origin, callback) => {
-    // 允許沒有 origin 的請求（例如 Postman、curl）
     if (!origin) return callback(null, true);
 
     if (allowedOrigins.includes(origin)) {
@@ -34,8 +34,6 @@ const corsOptions = {
 
 app.use(cors(corsOptions))
 app.use(express.json())
-
-
 
 // ====== 路由 (Routes) ======
 // TODO: 之後引入路由
@@ -54,6 +52,7 @@ const PORT = process.env.PORT || 3000
 
 app.use('/api', taxIdRoutes);
 app.use('/api', searchRoutes);
+app.use('/api', paymentRoutes);
 
 app.listen(PORT, () => {
   console.log(`Server is running on port ${PORT}`)

--- a/backend/index.js
+++ b/backend/index.js
@@ -30,7 +30,7 @@ const corsOptions = {
   },
   credentials: true,
   methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
-  allowedHeaders: ['Content-Type', 'Authorization'],
+  allowedHeaders: ['Content-Type', 'Authorization', 'x-garage-id', 'x-user-id'],
 };
 
 app.use(cors(corsOptions))

--- a/backend/index.js
+++ b/backend/index.js
@@ -3,6 +3,7 @@ import cors from 'cors'
 import taxIdRoutes from './src/routes/taxId.js';
 import searchRoutes from './src/routes/search.js';
 import paymentRoutes from './src/routes/payment.js';
+import subscriptionRoutes from './src/routes/subscription.js';
 import 'dotenv/config'
 
 
@@ -53,6 +54,7 @@ const PORT = process.env.PORT || 3000
 app.use('/api', taxIdRoutes);
 app.use('/api', searchRoutes);
 app.use('/api', paymentRoutes);
+app.use('/api', subscriptionRoutes);
 
 app.listen(PORT, () => {
   console.log(`Server is running on port ${PORT}`)

--- a/backend/src/controllers/paymentController.js
+++ b/backend/src/controllers/paymentController.js
@@ -10,19 +10,19 @@ const OEN_CHECKOUT_HOST = process.env.NODE_ENV === 'production'
 
 const buildRedirectUrl = (merchantId, checkoutId) => `https://${merchantId}.${OEN_CHECKOUT_HOST}/checkout/${checkoutId}`;
 
-// 簡易記憶體紀錄：將 orderId / checkoutId / transactionHid 對應到 user 與方案
+// 簡易記憶體紀錄：將 orderId / checkoutId / transactionHid 對應到 garage 與方案
 const paymentSessions = {
   byOrderId: new Map(),
   byCheckoutId: new Map(),
   byTransactionHid: new Map()
 };
 
-const rememberPaymentSession = ({ orderId, checkoutId, transactionHid, userId, planType, amount }) => {
+const rememberPaymentSession = ({ orderId, checkoutId, transactionHid, garageId, planType, amount }) => {
   const session = {
     orderId,
     checkoutId,
     transactionHid,
-    userId,
+    garageId,
     planType,
     amount,
     createdAt: new Date().toISOString()
@@ -44,7 +44,7 @@ export const createOenCheckout = async (req, res) => {
     planType
   } = req.body || {};
 
-  const userId = req.headers['x-user-id'] || 'demo-user';
+  const garageId = req.headers['x-garage-id'] || req.headers['x-user-id'] || null;
 
   const merchantId = process.env.OEN_MERCHANT_ID;
   const token = process.env.OEN_TOKEN;
@@ -69,6 +69,10 @@ export const createOenCheckout = async (req, res) => {
 
   if (!planType) {
     return res.status(400).json({ success: false, message: 'planType is required' });
+  }
+
+  if (!garageId) {
+    return res.status(400).json({ success: false, message: 'garageId required (x-garage-id or x-user-id header)' });
   }
 
   const payload = {
@@ -117,7 +121,7 @@ export const createOenCheckout = async (req, res) => {
       orderId,
       checkoutId,
       transactionHid,
-      userId,
+      garageId,
       planType,
       amount: Number(amount)
     });
@@ -193,11 +197,12 @@ export const handleOenWebhook = async (req, res) => {
     const status = payload.status;
     const success = payload.success === true;
 
-    // 盡量定位到原始 session（orderId -> user）
+    // 盡量定位到原始 session（transactionId -> garageId）
     let session = paymentSessions.byTransactionHid.get(transactionId);
 
     // 若未找到，透過交易查詢取回 orderId，再映射 session
     if (!session) {
+      console.log('Session not found by transactionHid, fetching from OEN API...');
       const tx = await fetchTransactionById(transactionId);
       if (tx?.orderId) {
         session = paymentSessions.byOrderId.get(tx.orderId);
@@ -207,19 +212,24 @@ export const handleOenWebhook = async (req, res) => {
     // 判斷成功條件：success=true 或 status=charged
     const isSuccess = success || status === 'charged';
 
+    console.log('Webhook processing:', { transactionId, isSuccess, hasSession: !!session, planType: session?.planType });
+
     if (session && isSuccess && session.planType === 'lifetime') {
-      setLifetimeFromPayment({
-        userId: session.userId,
+      await setLifetimeFromPayment({
+        garageId: session.garageId,
         orderId: session.orderId,
         transactionId
       });
+      console.log('✅ Lifetime subscription activated for garage:', session.garageId);
+    } else {
+      console.log('⚠️ Webhook conditions not met:', { session: !!session, isSuccess, planType: session?.planType });
     }
 
     // 總是回 200 讓 OEN 不要重試
     return res.status(200).json({ success: true });
   } catch (error) {
     console.error('Failed to process webhook:', error);
-    // 依據金流文件，失敗會重試；仍回 500 讓金流重試
+    
     return res.status(500).json({ success: false });
   }
 };

--- a/backend/src/controllers/paymentController.js
+++ b/backend/src/controllers/paymentController.js
@@ -1,0 +1,94 @@
+const OEN_BASE_URL = process.env.NODE_ENV === 'production'
+  ? 'https://payment-api.oen.tw'
+  : 'https://payment-api.testing.oen.tw';
+
+const OEN_CHECKOUT_HOST = process.env.NODE_ENV === 'production'
+  ? 'oen.tw'
+  : 'testing.oen.tw';
+
+const buildRedirectUrl = (merchantId, checkoutId) => `https://${merchantId}.${OEN_CHECKOUT_HOST}/checkout/${checkoutId}`;
+
+export const createOenCheckout = async (req, res) => {
+  const {
+    amount,
+    currency = 'TWD',
+    orderId,
+    successUrl,
+    failureUrl,
+    productDetail
+  } = req.body || {};
+
+  const merchantId = process.env.OEN_MERCHANT_ID;
+  const token = process.env.OEN_TOKEN;
+
+  if (!merchantId || !token) {
+    return res.status(500).json({
+      success: false,
+      message: 'payment config missing: OEN_MERCHANT_ID or OEN_TOKEN'
+    });
+  }
+
+  if (!amount || Number.isNaN(Number(amount)) || Number(amount) <= 0) {
+    return res.status(400).json({ success: false, message: 'amount is required and must be > 0' });
+  }
+
+  if (!orderId || !successUrl || !failureUrl) {
+    return res.status(400).json({
+      success: false,
+      message: 'orderId, successUrl, failureUrl are required'
+    });
+  }
+
+  const payload = {
+    merchantId,
+    amount: Number(amount),
+    currency,
+    orderId,
+    successUrl,
+    failureUrl,
+    productDetail
+  };
+
+  try {
+    const response = await fetch(`${OEN_BASE_URL}/checkout`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`
+      },
+      body: JSON.stringify(payload)
+    });
+
+    if (!response.ok) {
+      const errorBody = await response.text();
+      return res.status(response.status).json({
+        success: false,
+        message: 'checkout request failed',
+        detail: errorBody
+      });
+    }
+
+    const result = await response.json();
+
+    if (!result || result.code !== 'S0000' || !result.data?.id) {
+      return res.status(502).json({
+        success: false,
+        message: 'unexpected response from OEN',
+        detail: result
+      });
+    }
+
+    const checkoutId = result.data.id;
+    const redirectUrl = buildRedirectUrl(merchantId, checkoutId);
+
+    return res.json({
+      success: true,
+      checkoutId,
+      transactionHid: result.data.transactionHid,
+      redirectUrl
+    });
+  } catch (error) {
+    console.error('Failed to create OEN checkout:', error);
+    return res.status(500).json({ success: false, message: 'failed to create checkout' });
+  }
+};

--- a/backend/src/controllers/paymentController.js
+++ b/backend/src/controllers/paymentController.js
@@ -92,3 +92,68 @@ export const createOenCheckout = async (req, res) => {
     return res.status(500).json({ success: false, message: 'failed to create checkout' });
   }
 };
+
+export const getOEN_BASE_URL = () => (
+  process.env.NODE_ENV === 'production' ? 'https://payment-api.oen.tw' : 'https://payment-api.testing.oen.tw'
+);
+
+export const getOenTransaction = async (req, res) => {
+  const { id } = req.params || {};
+
+  const token = process.env.OEN_TOKEN;
+  if (!token) {
+    return res.status(500).json({ success: false, message: 'payment config missing: OEN_TOKEN' });
+  }
+  if (!id) {
+    return res.status(400).json({ success: false, message: 'id (transactionId or transactionHid) is required' });
+  }
+
+  try {
+    const response = await fetch(`${getOEN_BASE_URL()}/transactions/${encodeURIComponent(id)}`, {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`
+      }
+    });
+
+    const result = await response.json().catch(() => ({}));
+
+    if (!response.ok) {
+      return res.status(response.status).json({ success: false, message: 'failed to fetch transaction', detail: result });
+    }
+
+    return res.json({ success: result.code === 'S0000', data: result.data, raw: result });
+  } catch (error) {
+    console.error('Failed to get OEN transaction:', error);
+    return res.status(500).json({ success: false, message: 'failed to get transaction' });
+  }
+};
+
+export const handleOenWebhook = async (req, res) => {
+  // Webhook 會重試 3 次 第一次 2 秒 第二次 4 秒 第三次 6 秒
+  const payload = req.body || {};
+  const merchantId = process.env.OEN_MERCHANT_ID;
+
+  if (!merchantId) {
+    return res.status(500).json({ success: false, message: 'payment config missing: OEN_MERCHANT_ID' });
+  }
+
+  if (!payload.id || !payload.merchantId) {
+    return res.status(400).json({ success: false, message: 'invalid webhook payload' });
+  }
+
+  if (payload.merchantId !== merchantId) {
+    return res.status(403).json({ success: false, message: 'merchant mismatch' });
+  }
+
+  try {
+    // TODO: 將 webhook 狀態寫入資料庫（transactionId、status、purpose、success 等）並做冪等更新
+    // 目前先記錄 log 與回覆 200，避免 OEN 重試
+    console.log('OEN webhook received:', payload);
+    return res.status(200).json({ success: true });
+  } catch (error) {
+    console.error('Failed to process webhook:', error);
+    // 依據金流文件，失敗會重試；仍回 500 讓金流重試
+    return res.status(500).json({ success: false });
+  }
+};

--- a/backend/src/controllers/paymentController.js
+++ b/backend/src/controllers/paymentController.js
@@ -1,3 +1,5 @@
+import { setLifetimeFromPayment } from './subscriptionController.js';
+
 const OEN_BASE_URL = process.env.NODE_ENV === 'production'
   ? 'https://payment-api.oen.tw'
   : 'https://payment-api.testing.oen.tw';
@@ -8,6 +10,29 @@ const OEN_CHECKOUT_HOST = process.env.NODE_ENV === 'production'
 
 const buildRedirectUrl = (merchantId, checkoutId) => `https://${merchantId}.${OEN_CHECKOUT_HOST}/checkout/${checkoutId}`;
 
+// 簡易記憶體紀錄：將 orderId / checkoutId / transactionHid 對應到 user 與方案
+const paymentSessions = {
+  byOrderId: new Map(),
+  byCheckoutId: new Map(),
+  byTransactionHid: new Map()
+};
+
+const rememberPaymentSession = ({ orderId, checkoutId, transactionHid, userId, planType, amount }) => {
+  const session = {
+    orderId,
+    checkoutId,
+    transactionHid,
+    userId,
+    planType,
+    amount,
+    createdAt: new Date().toISOString()
+  };
+
+  if (orderId) paymentSessions.byOrderId.set(orderId, session);
+  if (checkoutId) paymentSessions.byCheckoutId.set(checkoutId, session);
+  if (transactionHid) paymentSessions.byTransactionHid.set(transactionHid, session);
+};
+
 export const createOenCheckout = async (req, res) => {
   const {
     amount,
@@ -15,8 +40,11 @@ export const createOenCheckout = async (req, res) => {
     orderId,
     successUrl,
     failureUrl,
-    productDetail
+    productDetail,
+    planType
   } = req.body || {};
+
+  const userId = req.headers['x-user-id'] || 'demo-user';
 
   const merchantId = process.env.OEN_MERCHANT_ID;
   const token = process.env.OEN_TOKEN;
@@ -37,6 +65,10 @@ export const createOenCheckout = async (req, res) => {
       success: false,
       message: 'orderId, successUrl, failureUrl are required'
     });
+  }
+
+  if (!planType) {
+    return res.status(400).json({ success: false, message: 'planType is required' });
   }
 
   const payload = {
@@ -80,6 +112,15 @@ export const createOenCheckout = async (req, res) => {
 
     const checkoutId = result.data.id;
     const transactionHid = result.data.transactionHid;
+
+    rememberPaymentSession({
+      orderId,
+      checkoutId,
+      transactionHid,
+      userId,
+      planType,
+      amount: Number(amount)
+    });
     const redirectUrl = buildRedirectUrl(merchantId, checkoutId);
 
     return res.json({
@@ -148,9 +189,33 @@ export const handleOenWebhook = async (req, res) => {
   }
 
   try {
-    // TODO: 將 webhook 狀態寫入資料庫（transactionId、status、purpose、success 等）並做冪等更新
-    // 目前先記錄 log 與回覆 200，避免 OEN 重試
-    console.log('OEN webhook received:', payload);
+    const transactionId = payload.id;
+    const status = payload.status;
+    const success = payload.success === true;
+
+    // 盡量定位到原始 session（orderId -> user）
+    let session = paymentSessions.byTransactionHid.get(transactionId);
+
+    // 若未找到，透過交易查詢取回 orderId，再映射 session
+    if (!session) {
+      const tx = await fetchTransactionById(transactionId);
+      if (tx?.orderId) {
+        session = paymentSessions.byOrderId.get(tx.orderId);
+      }
+    }
+
+    // 判斷成功條件：success=true 或 status=charged
+    const isSuccess = success || status === 'charged';
+
+    if (session && isSuccess && session.planType === 'lifetime') {
+      setLifetimeFromPayment({
+        userId: session.userId,
+        orderId: session.orderId,
+        transactionId
+      });
+    }
+
+    // 總是回 200 讓 OEN 不要重試
     return res.status(200).json({ success: true });
   } catch (error) {
     console.error('Failed to process webhook:', error);
@@ -158,3 +223,26 @@ export const handleOenWebhook = async (req, res) => {
     return res.status(500).json({ success: false });
   }
 };
+
+async function fetchTransactionById(id) {
+  const token = process.env.OEN_TOKEN;
+  if (!token || !id) return null;
+
+  try {
+    const response = await fetch(`${getOEN_BASE_URL()}/transactions/${encodeURIComponent(id)}`, {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`
+      }
+    });
+
+    const result = await response.json().catch(() => ({}));
+    if (!response.ok || result.code !== 'S0000') {
+      return null;
+    }
+    return result.data;
+  } catch (error) {
+    console.error('Failed to fetch transaction detail:', error);
+    return null;
+  }
+}

--- a/backend/src/controllers/paymentController.js
+++ b/backend/src/controllers/paymentController.js
@@ -79,12 +79,13 @@ export const createOenCheckout = async (req, res) => {
     }
 
     const checkoutId = result.data.id;
+    const transactionHid = result.data.transactionHid;
     const redirectUrl = buildRedirectUrl(merchantId, checkoutId);
 
     return res.json({
       success: true,
       checkoutId,
-      transactionHid: result.data.transactionHid,
+      transactionHid,
       redirectUrl
     });
   } catch (error) {

--- a/backend/src/controllers/paymentController.js
+++ b/backend/src/controllers/paymentController.js
@@ -9,8 +9,15 @@ const OEN_CHECKOUT_HOST = process.env.NODE_ENV === 'production'
   : 'testing.oen.tw';
 
 const buildRedirectUrl = (merchantId, checkoutId) => `https://${merchantId}.${OEN_CHECKOUT_HOST}/checkout/${checkoutId}`;
-
-// 簡易記憶體紀錄：將 orderId / checkoutId / transactionHid 對應到 garage 與方案
+/**
+ * ⚠️ NOTE:
+ * This in-memory paymentSessions store is used ONLY for demo / development.
+ * It is NOT production-ready.
+ *
+ * In a production environment, payment session data should be persisted
+ * in a database or Redis to prevent data loss on server restart or
+ * multi-instance deployments.
+ */
 const paymentSessions = {
   byOrderId: new Map(),
   byCheckoutId: new Map(),
@@ -208,6 +215,15 @@ export const handleOenWebhook = async (req, res) => {
         session = paymentSessions.byOrderId.get(tx.orderId);
       }
     }
+    if (!session) {
+         console.warn('[PAYMENT] Webhook skipped due to missing session (demo mode).', {
+         transactionId
+        });
+
+         // IMPORTANT:
+         // Always return 200 to prevent webhook retry storm
+          return res.status(200).json({ success: true });
+        }
 
     // 判斷成功條件：success=true 或 status=charged
     const isSuccess = success || status === 'charged';
@@ -229,7 +245,7 @@ export const handleOenWebhook = async (req, res) => {
     return res.status(200).json({ success: true });
   } catch (error) {
     console.error('Failed to process webhook:', error);
-    
+
     return res.status(500).json({ success: false });
   }
 };

--- a/backend/src/controllers/subscriptionController.js
+++ b/backend/src/controllers/subscriptionController.js
@@ -2,9 +2,10 @@
 // TODO: 之後整合 Supabase 資料庫
 const subscriptions = new Map();
 
+const getUserId = (req) => req.headers['x-user-id'] || 'demo-user';
+
 export const getCurrentSubscription = async (req, res) => {
-  // TODO: 從 session/JWT 取得用戶 ID
-  const userId = req.headers['x-user-id'] || 'demo-user';
+  const userId = getUserId(req);
 
   const subscription = subscriptions.get(userId);
 
@@ -22,8 +23,7 @@ export const getCurrentSubscription = async (req, res) => {
 };
 
 export const activateTrial = async (req, res) => {
-  // TODO: 從 session/JWT 取得用戶 ID
-  const userId = req.headers['x-user-id'] || 'demo-user';
+  const userId = getUserId(req);
 
   // 檢查是否已有訂閱
   if (subscriptions.has(userId)) {
@@ -59,8 +59,7 @@ export const activateTrial = async (req, res) => {
 };
 
 export const activateLifetime = async (req, res) => {
-  // TODO: 從 session/JWT 取得用戶 ID 和 webhook 驗證的交易資訊
-  const userId = req.headers['x-user-id'] || 'demo-user';
+  const userId = getUserId(req);
   const { orderId, transactionId } = req.body;
 
   // TODO: 驗證交易是否成功（從資料庫查詢 webhook 記錄）
@@ -85,4 +84,23 @@ export const activateLifetime = async (req, res) => {
     success: true,
     subscription
   });
+};
+
+export const setLifetimeFromPayment = ({ userId, orderId, transactionId }) => {
+  const subscription = {
+    id: `lifetime_${Date.now()}`,
+    planType: 'lifetime',
+    status: 'active',
+    purchaseDate: new Date().toISOString(),
+    orderId,
+    transactionId,
+    features: {
+      bookingManagement: true,
+      reviewSystem: true,
+      profileDisplay: true
+    }
+  };
+
+  subscriptions.set(userId, subscription);
+  return subscription;
 };

--- a/backend/src/controllers/subscriptionController.js
+++ b/backend/src/controllers/subscriptionController.js
@@ -26,12 +26,15 @@ const mapGarageToSubscription = (garage) => {
 export const getCurrentSubscription = async (req, res) => {
   const garageId = getGarageId(req);
 
-  if (!garageId) {
-    return res.status(400).json({
-      success: false,
-      message: 'garage ID required (x-garage-id or x-user-id header)'
-    });
+ if (!garageId) {
+  if (process.env.NODE_ENV !== 'production') {
+    return res.json({ success: true, subscription: null });
   }
+  return res.status(400).json({
+    success: false,
+    message: 'garage ID required (x-garage-id or x-user-id header)'
+  });
+}
 
   try {
     const { data: garage, error } = await supabase

--- a/backend/src/controllers/subscriptionController.js
+++ b/backend/src/controllers/subscriptionController.js
@@ -1,106 +1,178 @@
-// 暫時用記憶體存儲訂閱資訊（開發階段）
-// TODO: 之後整合 Supabase 資料庫
-const subscriptions = new Map();
+import supabase from '../configs/supabase.js';
 
-const getUserId = (req) => req.headers['x-user-id'] || 'demo-user';
+const getGarageId = (req) => req.headers['x-garage-id'] || req.headers['x-user-id'] || null;
+
+const mapGarageToSubscription = (garage) => {
+  if (!garage) return null;
+
+  const planType = garage.subscription_status === 'none' ? null : garage.subscription_status;
+
+  return {
+    id: garage.id,
+    planType,
+    status: 'active',
+    trialStartDate: garage.subscription_date,
+    trialExpiryDate: garage.trial_expiry_date,
+    purchaseDate: garage.subscription_date,
+    transactionId: garage.last_transaction_id,
+    features: {
+      bookingManagement: planType === 'trial' || planType === 'lifetime',
+      reviewSystem: planType === 'trial' || planType === 'lifetime',
+      profileDisplay: true
+    }
+  };
+};
 
 export const getCurrentSubscription = async (req, res) => {
-  const userId = getUserId(req);
+  const garageId = getGarageId(req);
 
-  const subscription = subscriptions.get(userId);
-
-  if (!subscription) {
-    return res.json({
-      success: true,
-      subscription: null
+  if (!garageId) {
+    return res.status(400).json({
+      success: false,
+      message: 'garage ID required (x-garage-id or x-user-id header)'
     });
   }
 
-  return res.json({
-    success: true,
-    subscription
-  });
+  try {
+    const { data: garage, error } = await supabase
+      .from('garages')
+      .select('id, subscription_status, trial_expiry_date, subscription_date, last_transaction_id')
+      .eq('id', garageId)
+      .single();
+
+    if (error) {
+      console.error('Failed to fetch garage subscription:', error);
+      return res.status(500).json({ success: false, message: 'failed to fetch subscription' });
+    }
+
+    return res.json({
+      success: true,
+      subscription: mapGarageToSubscription(garage)
+    });
+  } catch (error) {
+    console.error('Error fetching subscription:', error);
+    return res.status(500).json({ success: false, message: 'server error' });
+  }
 };
 
 export const activateTrial = async (req, res) => {
-  const userId = getUserId(req);
+  const garageId = getGarageId(req);
 
-  // 檢查是否已有訂閱
-  if (subscriptions.has(userId)) {
+  if (!garageId) {
     return res.status(400).json({
       success: false,
-      message: '您已經有訂閱方案'
+      message: 'garage ID required'
     });
   }
 
-  const now = new Date();
-  const expiryDate = new Date(now);
-  expiryDate.setDate(expiryDate.getDate() + 30);
+  try {
+    const { data: garage, error: fetchError } = await supabase
+      .from('garages')
+      .select('subscription_status')
+      .eq('id', garageId)
+      .single();
 
-  const subscription = {
-    id: `trial_${Date.now()}`,
-    planType: 'trial',
-    status: 'active',
-    trialStartDate: now.toISOString(),
-    trialExpiryDate: expiryDate.toISOString(),
-    features: {
-      bookingManagement: true,
-      reviewSystem: true,
-      profileDisplay: true
+    if (fetchError) {
+      console.error('Failed to fetch garage:', fetchError);
+      return res.status(500).json({ success: false, message: 'failed to check garage' });
     }
-  };
 
-  subscriptions.set(userId, subscription);
+    if (garage.subscription_status !== 'none') {
+      return res.status(400).json({
+        success: false,
+        message: '您已經有訂閱方案'
+      });
+    }
 
-  return res.json({
-    success: true,
-    subscription
-  });
+    const now = new Date();
+    const expiryDate = new Date(now);
+    expiryDate.setDate(expiryDate.getDate() + 30);
+
+    const { data: updatedGarage, error: updateError } = await supabase
+      .from('garages')
+      .update({
+        subscription_status: 'trial',
+        trial_expiry_date: expiryDate.toISOString(),
+        subscription_date: now.toISOString()
+      })
+      .eq('id', garageId)
+      .select()
+      .single();
+
+    if (updateError) {
+      console.error('Failed to activate trial:', updateError);
+      return res.status(500).json({ success: false, message: 'failed to activate trial' });
+    }
+
+    return res.json({
+      success: true,
+      subscription: mapGarageToSubscription(updatedGarage)
+    });
+  } catch (error) {
+    console.error('Error activating trial:', error);
+    return res.status(500).json({ success: false, message: 'server error' });
+  }
 };
 
 export const activateLifetime = async (req, res) => {
-  const userId = getUserId(req);
+  const garageId = getGarageId(req);
   const { orderId, transactionId } = req.body;
 
-  // TODO: 驗證交易是否成功（從資料庫查詢 webhook 記錄）
+  if (!garageId) {
+    return res.status(400).json({
+      success: false,
+      message: 'garage ID required'
+    });
+  }
 
-  const subscription = {
-    id: `lifetime_${Date.now()}`,
-    planType: 'lifetime',
-    status: 'active',
-    purchaseDate: new Date().toISOString(),
-    orderId,
-    transactionId,
-    features: {
-      bookingManagement: true,
-      reviewSystem: true,
-      profileDisplay: true
+  try {
+    const { data: updatedGarage, error } = await supabase
+      .from('garages')
+      .update({
+        subscription_status: 'lifetime',
+        subscription_date: new Date().toISOString(),
+        last_transaction_id: transactionId
+      })
+      .eq('id', garageId)
+      .select()
+      .single();
+
+    if (error) {
+      console.error('Failed to activate lifetime:', error);
+      return res.status(500).json({ success: false, message: 'failed to activate lifetime' });
     }
-  };
 
-  subscriptions.set(userId, subscription);
-
-  return res.json({
-    success: true,
-    subscription
-  });
+    return res.json({
+      success: true,
+      subscription: mapGarageToSubscription(updatedGarage)
+    });
+  } catch (error) {
+    console.error('Error activating lifetime:', error);
+    return res.status(500).json({ success: false, message: 'server error' });
+  }
 };
 
-export const setLifetimeFromPayment = ({ userId, orderId, transactionId }) => {
-  const subscription = {
-    id: `lifetime_${Date.now()}`,
-    planType: 'lifetime',
-    status: 'active',
-    purchaseDate: new Date().toISOString(),
-    orderId,
-    transactionId,
-    features: {
-      bookingManagement: true,
-      reviewSystem: true,
-      profileDisplay: true
-    }
-  };
+export const setLifetimeFromPayment = async ({ garageId, orderId, transactionId }) => {
+  try {
+    const { data: updatedGarage, error } = await supabase
+      .from('garages')
+      .update({
+        subscription_status: 'lifetime',
+        subscription_date: new Date().toISOString(),
+        last_transaction_id: transactionId
+      })
+      .eq('id', garageId)
+      .select()
+      .single();
 
-  subscriptions.set(userId, subscription);
-  return subscription;
+    if (error) {
+      console.error('Failed to set lifetime from payment:', error);
+      return null;
+    }
+
+    return mapGarageToSubscription(updatedGarage);
+  } catch (error) {
+    console.error('Error setting lifetime:', error);
+    return null;
+  }
 };

--- a/backend/src/controllers/subscriptionController.js
+++ b/backend/src/controllers/subscriptionController.js
@@ -1,0 +1,88 @@
+// 暫時用記憶體存儲訂閱資訊（開發階段）
+// TODO: 之後整合 Supabase 資料庫
+const subscriptions = new Map();
+
+export const getCurrentSubscription = async (req, res) => {
+  // TODO: 從 session/JWT 取得用戶 ID
+  const userId = req.headers['x-user-id'] || 'demo-user';
+
+  const subscription = subscriptions.get(userId);
+
+  if (!subscription) {
+    return res.json({
+      success: true,
+      subscription: null
+    });
+  }
+
+  return res.json({
+    success: true,
+    subscription
+  });
+};
+
+export const activateTrial = async (req, res) => {
+  // TODO: 從 session/JWT 取得用戶 ID
+  const userId = req.headers['x-user-id'] || 'demo-user';
+
+  // 檢查是否已有訂閱
+  if (subscriptions.has(userId)) {
+    return res.status(400).json({
+      success: false,
+      message: '您已經有訂閱方案'
+    });
+  }
+
+  const now = new Date();
+  const expiryDate = new Date(now);
+  expiryDate.setDate(expiryDate.getDate() + 30);
+
+  const subscription = {
+    id: `trial_${Date.now()}`,
+    planType: 'trial',
+    status: 'active',
+    trialStartDate: now.toISOString(),
+    trialExpiryDate: expiryDate.toISOString(),
+    features: {
+      bookingManagement: true,
+      reviewSystem: true,
+      profileDisplay: true
+    }
+  };
+
+  subscriptions.set(userId, subscription);
+
+  return res.json({
+    success: true,
+    subscription
+  });
+};
+
+export const activateLifetime = async (req, res) => {
+  // TODO: 從 session/JWT 取得用戶 ID 和 webhook 驗證的交易資訊
+  const userId = req.headers['x-user-id'] || 'demo-user';
+  const { orderId, transactionId } = req.body;
+
+  // TODO: 驗證交易是否成功（從資料庫查詢 webhook 記錄）
+
+  const subscription = {
+    id: `lifetime_${Date.now()}`,
+    planType: 'lifetime',
+    status: 'active',
+    purchaseDate: new Date().toISOString(),
+    orderId,
+    transactionId,
+    features: {
+      bookingManagement: true,
+      reviewSystem: true,
+      profileDisplay: true
+    }
+  };
+
+  subscriptions.set(userId, subscription);
+
+  return res.json({
+    success: true,
+    subscription
+  });
+};

--- a/backend/src/routes/payment.js
+++ b/backend/src/routes/payment.js
@@ -1,0 +1,16 @@
+import express from 'express';
+import rateLimit from 'express-rate-limit';
+import { createOenCheckout } from '../controllers/paymentController.js';
+
+const router = express.Router();
+
+const checkoutRateLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 60,
+  standardHeaders: true,
+  legacyHeaders: false
+});
+
+router.post('/payment/oen/checkout', checkoutRateLimiter, createOenCheckout);
+
+export default router;

--- a/backend/src/routes/payment.js
+++ b/backend/src/routes/payment.js
@@ -1,6 +1,6 @@
 import express from 'express';
 import rateLimit from 'express-rate-limit';
-import { createOenCheckout } from '../controllers/paymentController.js';
+import { createOenCheckout, getOenTransaction, handleOenWebhook } from '../controllers/paymentController.js';
 
 const router = express.Router();
 
@@ -12,5 +12,15 @@ const checkoutRateLimiter = rateLimit({
 });
 
 router.post('/payment/oen/checkout', checkoutRateLimiter, createOenCheckout);
+
+const queryRateLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 200,
+  standardHeaders: true,
+  legacyHeaders: false
+});
+router.get('/payment/oen/transactions/:id', queryRateLimiter, getOenTransaction);
+
+router.post('/payment/oen/webhook', handleOenWebhook);
 
 export default router;

--- a/backend/src/routes/subscription.js
+++ b/backend/src/routes/subscription.js
@@ -1,0 +1,22 @@
+import express from 'express';
+import rateLimit from 'express-rate-limit';
+import {
+  getCurrentSubscription,
+  activateTrial,
+  activateLifetime
+} from '../controllers/subscriptionController.js';
+
+const router = express.Router();
+
+const subscriptionRateLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 100,
+  standardHeaders: true,
+  legacyHeaders: false
+});
+
+router.get('/subscription/current', subscriptionRateLimiter, getCurrentSubscription);
+router.post('/trial/activate', subscriptionRateLimiter, activateTrial);
+router.post('/subscription/activate-lifetime', subscriptionRateLimiter, activateLifetime);
+
+export default router;

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -4,3 +4,6 @@
 
 VITE_SUPABASE_URL=your_supabase_project_url
 VITE_SUPABASE_ANON_KEY=your_supabase_anon_key
+
+# Google 網站驗證金鑰
+VITE_GOOGLE_SITE_VERIFICATION=your_google_site_verification_key

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -5,5 +5,9 @@
 VITE_SUPABASE_URL=your_supabase_project_url
 VITE_SUPABASE_ANON_KEY=your_supabase_anon_key
 
+# 後端 API URL
+# 開發環境使用本地後端，生產環境使用部署的後端
+VITE_API_URL=http://localhost:3000
+
 # Google 網站驗證金鑰
 VITE_GOOGLE_SITE_VERIFICATION=your_google_site_verification_key

--- a/frontend/src/components/payment/PaymentDrawer.vue
+++ b/frontend/src/components/payment/PaymentDrawer.vue
@@ -175,8 +175,8 @@ function handleClose() {
                             </div>
                           </div>
                         </button>
-
-                        <button
+//TODO: 暫時隱藏 Line Pay 選項(時間允許再補上)
+                        <!-- <button
                           @click="selectPaymentMethod('linepay')"
                           class="w-full p-4 rounded-lg border-2 transition-all text-left"
                           :class="[
@@ -202,7 +202,7 @@ function handleClose() {
                               <span class="material-symbols-outlined text-white text-sm">check</span>
                             </div>
                           </div>
-                        </button>
+                        </button> -->
                       </div>
 
                       <div v-if="plan.type === 'trial'" class="bg-blue-50 rounded-lg p-4">

--- a/frontend/src/components/payment/PaymentDrawer.vue
+++ b/frontend/src/components/payment/PaymentDrawer.vue
@@ -159,12 +159,12 @@ function handleClose() {
                         >
                           <div class="flex items-center justify-between">
                             <div class="flex items-center">
-                              <div class="w-12 h-12 bg-gradient-to-br from-blue-500 to-blue-600 rounded-lg flex items-center justify-center mr-4">
-                                <span class="text-white font-bold text-lg">應援</span>
+                              <div class="w-12 h-12 flex items-center justify-center mr-4">
+                                <span><img src="https://content.pstmn.io/18ff50bf-4171-49ef-ad8c-228216994aad/bG9nby5wbmc="></span>
                               </div>
                               <div>
-                                <p class="font-semibold text-gray-900">應援 Pay</p>
-                                <p class="text-sm text-gray-600">支援信用卡、ATM、超商付款</p>
+                                <p class="font-bold text-gray-900">應援金流</p>
+                                <p class="font-semibold text-sm text-gray-600">支援信用卡付款</p>
                               </div>
                             </div>
                             <div
@@ -187,12 +187,12 @@ function handleClose() {
                         >
                           <div class="flex items-center justify-between">
                             <div class="flex items-center">
-                              <div class="w-12 h-12 bg-[#00B900] rounded-lg flex items-center justify-center mr-4">
-                                <span class="text-white font-bold text-lg">LINE</span>
+                              <div class="w-12 h-12 flex items-center justify-center mr-4">
+                                <span><img src="https://d.line-scdn.net/linepay/portal/assets/img/portal/login-logo-pay.svg"></span>
                               </div>
                               <div>
-                                <p class="font-semibold text-gray-900">LINE Pay</p>
-                                <p class="text-sm text-gray-600">使用 LINE Pay 快速付款</p>
+                                <p class="font-bold text-gray-900">LINE Pay</p>
+                                <p class="font-semibold text-sm text-gray-600">使用 LINE Pay 快速付款</p>
                               </div>
                             </div>
                             <div

--- a/frontend/src/components/payment/PaymentDrawer.vue
+++ b/frontend/src/components/payment/PaymentDrawer.vue
@@ -60,12 +60,17 @@ async function handleConfirm() {
 
   isProcessing.value = true;
 
-  if (props.plan.type === 'trial') {
-    // 免費試用方案，傳遞 'trial' 作為識別
-    emit('select-payment', 'trial');
-  } else {
-    // 付費方案，傳遞使用者選擇的付款方式
-    emit('select-payment', selectedPaymentMethod.value!);
+  try {
+    if (props.plan.type === 'trial') {
+      // 免費試用方案，傳遞 'trial' 作為識別
+      emit('select-payment', 'trial');
+    } else {
+      // 付費方案，傳遞使用者選擇的付款方式
+      emit('select-payment', selectedPaymentMethod.value!);
+    }
+  } finally {
+    // 確保無論成功或失敗都能重置狀態
+    // 由父組件決定是否關閉 drawer
   }
 }
 
@@ -73,6 +78,7 @@ function handleClose() {
   if (isProcessing.value || isTermsModalOpen.value) return;
   agreedToTerms.value = false;
   selectedPaymentMethod.value = null;
+  isProcessing.value = false;
   emit('close');
 }
 </script>

--- a/frontend/src/components/payment/PaymentDrawer.vue
+++ b/frontend/src/components/payment/PaymentDrawer.vue
@@ -175,34 +175,6 @@ function handleClose() {
                             </div>
                           </div>
                         </button>
-//TODO: 暫時隱藏 Line Pay 選項(時間允許再補上)
-                        <!-- <button
-                          @click="selectPaymentMethod('linepay')"
-                          class="w-full p-4 rounded-lg border-2 transition-all text-left"
-                          :class="[
-                            selectedPaymentMethod === 'linepay'
-                              ? 'border-[#00B900] bg-green-50'
-                              : 'border-gray-200 hover:border-gray-300'
-                          ]"
-                        >
-                          <div class="flex items-center justify-between">
-                            <div class="flex items-center">
-                              <div class="w-12 h-12 flex items-center justify-center mr-4">
-                                <span><img src="https://d.line-scdn.net/linepay/portal/assets/img/portal/login-logo-pay.svg"></span>
-                              </div>
-                              <div>
-                                <p class="font-bold text-gray-900">LINE Pay</p>
-                                <p class="font-semibold text-sm text-gray-600">使用 LINE Pay 快速付款</p>
-                              </div>
-                            </div>
-                            <div
-                              v-if="selectedPaymentMethod === 'linepay'"
-                              class="w-6 h-6 rounded-full bg-[#00B900] flex items-center justify-center"
-                            >
-                              <span class="material-symbols-outlined text-white text-sm">check</span>
-                            </div>
-                          </div>
-                        </button> -->
                       </div>
 
                       <div v-if="plan.type === 'trial'" class="bg-blue-50 rounded-lg p-4">

--- a/frontend/src/stores/subscription.ts
+++ b/frontend/src/stores/subscription.ts
@@ -88,16 +88,18 @@ export const useSubscriptionStore = defineStore('subscription', () => {
       const userStore = useUserStore();
 
       // 從登入狀態取得 garageId，未登入時使用測試 ID
-      const garageId = userStore.currentUser?.id || '1'; // 使用 user id 作為 garageId
+      const garageId = userStore.currentUser?.id || (import.meta.env.DEV ? '1' : null);
 
+      const headers: Record<string, string> = {
+        'Content-Type': 'application/json',
+      };
+      if (garageId) {
+        headers['x-garage-id'] = garageId;
+      }
       const response = await fetch(`${apiUrl}/api/subscription/current`, {
         credentials: 'include',
-        headers: {
-          'Content-Type': 'application/json',
-          'x-garage-id': garageId
-        }
+        headers,
       });
-
       const data = await response.json();
 
       if (data.success && data.subscription) {
@@ -125,15 +127,19 @@ export const useSubscriptionStore = defineStore('subscription', () => {
       const userStore = useUserStore();
 
       // 從登入狀態取得 garageId，未登入時使用測試 ID
-      const garageId = userStore.currentUser?.id || '1'; // 使用 user id 作為 garageId
+      const garageId = userStore.currentUser?.id || (import.meta.env.DEV ? '1' : null);
+
+      const headers: Record<string, string> = {
+        'Content-Type': 'application/json',
+      };
+      if (garageId) {
+        headers['x-garage-id'] = garageId;
+      }
 
       const response = await fetch(`${apiUrl}/api/trial/activate`, {
         method: 'POST',
         credentials: 'include',
-        headers: {
-          'Content-Type': 'application/json',
-          'x-garage-id': garageId
-        }
+        headers,
       });
 
       const data = await response.json();

--- a/frontend/src/stores/subscription.ts
+++ b/frontend/src/stores/subscription.ts
@@ -1,5 +1,6 @@
 import { defineStore } from 'pinia';
 import { ref, computed } from 'vue';
+import { useUserStore } from './user';
 
 export type PlanType = 'trial' | 'lifetime' | null;
 
@@ -84,10 +85,16 @@ export const useSubscriptionStore = defineStore('subscription', () => {
 
     try {
       const apiUrl = import.meta.env.VITE_API_URL || '';
+      const userStore = useUserStore();
+
+      // 從登入狀態取得 garageId，未登入時使用測試 ID
+      const garageId = userStore.currentUser?.id || '1'; // 使用 user id 作為 garageId
+
       const response = await fetch(`${apiUrl}/api/subscription/current`, {
         credentials: 'include',
         headers: {
           'Content-Type': 'application/json',
+          'x-garage-id': garageId
         }
       });
 
@@ -115,11 +122,17 @@ export const useSubscriptionStore = defineStore('subscription', () => {
 
     try {
       const apiUrl = import.meta.env.VITE_API_URL || '';
+      const userStore = useUserStore();
+
+      // 從登入狀態取得 garageId，未登入時使用測試 ID
+      const garageId = userStore.currentUser?.id || '1'; // 使用 user id 作為 garageId
+
       const response = await fetch(`${apiUrl}/api/trial/activate`, {
         method: 'POST',
         credentials: 'include',
         headers: {
           'Content-Type': 'application/json',
+          'x-garage-id': garageId
         }
       });
 

--- a/frontend/src/views/Garage/SubscriptionSelection.vue
+++ b/frontend/src/views/Garage/SubscriptionSelection.vue
@@ -100,13 +100,13 @@ async function createPayment(plan: typeof pricingPlans[0], paymentMethod: 'oen' 
   // 從登入狀態取得 garageId，未登入時使用測試 ID
   const garageId = userStore.currentUser?.id
     ? String(userStore.currentUser.id)
-    : '1'; // 開發測試用 fallback
+    : (import.meta.env.DEV ? '1' : null); // 開發測試用 fallback
 
   const response = await fetch(endpoint, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      'x-garage-id': String(garageId)
+      ...(garageId ? { 'x-garage-id': String(garageId) } : {})
     },
     body: JSON.stringify({
       amount: plan.price,

--- a/frontend/src/views/Garage/SubscriptionSelection.vue
+++ b/frontend/src/views/Garage/SubscriptionSelection.vue
@@ -4,9 +4,11 @@ import { useRouter } from 'vue-router';
 import PricingCard from '@/components/ui/PricingCard.vue';
 import PaymentDrawer from '@/components/payment/PaymentDrawer.vue';
 import { useSubscriptionStore } from '@/stores/subscription';
+import { useUserStore } from '@/stores/user';
 
 const router = useRouter();
 const subscriptionStore = useSubscriptionStore();
+const userStore = useUserStore();
 
 const pricingPlans = [
   {
@@ -60,11 +62,15 @@ async function handlePaymentMethodSelect(paymentMethod: 'oen' | 'linepay' | 'tri
       await activateFreeTrial();
     } else {
       // 付費方案，使用選擇的付款方式
+      // 注意：成功時會直接跳轉，不會回到這裡
       await createPayment(selectedPlan.value, paymentMethod);
     }
   } catch (error) {
     console.error('處理失敗:', error);
-    alert('操作失敗,請稍後再試');
+    const message = error instanceof Error ? error.message : '請稍後再試';
+    alert('操作失敗：' + message);
+    // 失敗時關閉 drawer，讓用戶可以重新選擇
+    closeDrawer();
   }
 }
 
@@ -78,7 +84,7 @@ async function activateFreeTrial() {
       query: { type: 'trial' }
     });
   } else {
-    alert(result.message || '啟動試用失敗，請稍後再試');
+    throw new Error(result.message || '啟動試用失敗');
   }
 }
 
@@ -87,13 +93,18 @@ async function createPayment(plan: typeof pricingPlans[0], paymentMethod: 'oen' 
     ? 'http://localhost:3000/api/payment/oen/checkout'
     : 'http://localhost:3000/api/payment/linepay/checkout';
 
-  // 生成唯一的 orderId
   const orderId = `ORDER_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+
+  // 從登入狀態取得 garageId，未登入時使用測試 ID
+  const garageId = userStore.currentUser?.id
+    ? String(userStore.currentUser.id)
+    : '1'; // 開發測試用 fallback
 
   const response = await fetch(endpoint, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
+      'x-garage-id': String(garageId)
     },
     body: JSON.stringify({
       amount: plan.price,

--- a/frontend/src/views/Garage/SubscriptionSelection.vue
+++ b/frontend/src/views/Garage/SubscriptionSelection.vue
@@ -83,12 +83,13 @@ async function activateFreeTrial() {
 }
 
 async function createPayment(plan: typeof pricingPlans[0], paymentMethod: 'oen' | 'linepay') {
-  // TODO: 呼叫不同的金流 API
   const endpoint = paymentMethod === 'oen'
-    ? '/api/payment/oen/create-checkout'
-    : '/api/payment/linepay/create-checkout';
+    ? 'http://localhost:3000/api/payment/oen/checkout'
+    : 'http://localhost:3000/api/payment/linepay/checkout';
 
-  // 由後端產生唯一的 orderId，確保安全性和唯一性
+  // 生成唯一的 orderId
+  const orderId = `ORDER_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+
   const response = await fetch(endpoint, {
     method: 'POST',
     headers: {
@@ -96,18 +97,19 @@ async function createPayment(plan: typeof pricingPlans[0], paymentMethod: 'oen' 
     },
     body: JSON.stringify({
       amount: plan.price,
-      planType: plan.type,
-      description: `${plan.title} - carE 平台訂閱`,
-      successUrl: `${window.location.origin}/garage/subscription/success?type=lifetime`,
+      currency: 'TWD',
+      orderId: orderId,
+      successUrl: `${window.location.origin}/garage/subscription/success?type=${plan.type}`,
       failureUrl: `${window.location.origin}/garage/subscription/failure`,
+      productDetail: `${plan.title} - carE 平台訂閱`,
     }),
   });
 
   const data = await response.json();
 
-  // 後端會回傳包含 orderId 和 checkoutUrl 的資料
-  if (data.success && data.checkoutUrl) {
-    window.location.href = data.checkoutUrl;
+  // 後端回傳 redirectUrl（跳轉到應援金流頁面）
+  if (data.success && data.redirectUrl) {
+    window.location.href = data.redirectUrl;
   } else {
     throw new Error(data.message || '建立付款失敗');
   }

--- a/frontend/src/views/Garage/SubscriptionSelection.vue
+++ b/frontend/src/views/Garage/SubscriptionSelection.vue
@@ -89,9 +89,11 @@ async function activateFreeTrial() {
 }
 
 async function createPayment(plan: typeof pricingPlans[0], paymentMethod: 'oen' | 'linepay') {
+  // 使用環境變數設定 API URL
+  const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000';
   const endpoint = paymentMethod === 'oen'
-    ? 'http://localhost:3000/api/payment/oen/checkout'
-    : 'http://localhost:3000/api/payment/linepay/checkout';
+    ? `${API_BASE_URL}/api/payment/oen/checkout`
+    : `${API_BASE_URL}/api/payment/linepay/checkout`;
 
   const orderId = `ORDER_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
 

--- a/frontend/src/views/Garage/SubscriptionSelection.vue
+++ b/frontend/src/views/Garage/SubscriptionSelection.vue
@@ -99,6 +99,7 @@ async function createPayment(plan: typeof pricingPlans[0], paymentMethod: 'oen' 
       amount: plan.price,
       currency: 'TWD',
       orderId: orderId,
+      planType: plan.type,
       successUrl: `${window.location.origin}/garage/subscription/success?type=${plan.type}`,
       failureUrl: `${window.location.origin}/garage/subscription/failure`,
       productDetail: `${plan.title} - carE 平台訂閱`,

--- a/frontend/src/views/Garage/SubscriptionSuccess.vue
+++ b/frontend/src/views/Garage/SubscriptionSuccess.vue
@@ -44,7 +44,7 @@ const trialExpiryInfo = computed(() => {
   return `試用期限至 ${formatted}`;
 });
 
-const countdown = ref(5);
+const countdown = ref(10);
 let countdownTimer: ReturnType<typeof setInterval> | null = null;
 
 const startCountdown = () => {


### PR DESCRIPTION
### 已使用[應援金流](https://tech.oen.tw/posts/30zdZkSThhyaqmCXKhX7c8aTq8Y?locale=zh-TW)串接
測試卡號： 4242 4242 4242 4242
日期與後三碼 隨意

>注意！ 目前直接寫兩個狀態
* ✅ 開發環境：如果未登入或 [garageId](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) 不存在 → 使用id: '1' 測試
* ✅ 正式環境：登入後如果 [user.garageId](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) 有值 → 使用真實 ID

上線前 確保登入流程會設定 [userStore.currentUser.garageId](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)，這樣就會自動使用真實 ID


#### 實測成功畫面：

https://github.com/user-attachments/assets/140549df-3fb4-425b-9530-e4d3f94445fd

#### 手機版畫面：
<img width="296" height="632" alt="截圖 2026-01-26 凌晨2 15 38" src="https://github.com/user-attachments/assets/a079d97d-7db0-4634-aa4f-07a5fc7125fc" />
<img width="289" height="628" alt="截圖 2026-01-26 凌晨2 15 51" src="https://github.com/user-attachments/assets/7d6283da-60a5-4a45-8c79-ecd21701c26f" />

#### 成功同時更新方案狀態到supabase的garages table 
<img width="1064" height="71" alt="截圖 2026-01-26 凌晨1 53 29" src="https://github.com/user-attachments/assets/eb17e0b6-c4d9-4e6d-ac18-7f1084e64130" />
<img width="467" height="131" alt="截圖 2026-01-26 凌晨1 55 10" src="https://github.com/user-attachments/assets/5867240c-3554-491b-94c1-a526758b2cf7" />

### 錯誤畫面（以金額小於100）示範：
https://github.com/user-attachments/assets/55e5b2b0-a0ca-48a4-b2e5-41b97b4cdd26

-----

### Linepay時間允許再加入



