### PR TITLE
#200-2 維修廠後台與金流串接服務全部代碼重構

### DIFF
--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -1,4 +1,5 @@
 import { createRouter, createWebHistory } from 'vue-router';
+import { useAuthStore } from '@/stores/auth';
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -125,7 +126,7 @@ const router = createRouter({
       component: () => import('@/views/Garage/SubscriptionSuccess.vue'),
       meta: {
         title: '訂閱成功 - carE',
-        requiresAuth: true,
+        // 不需要 requiresAuth，因為從金流頁面跳回時認證狀態可能還沒恢復
       },
     },
     {
@@ -134,7 +135,7 @@ const router = createRouter({
       component: () => import('@/views/Garage/SubscriptionFailure.vue'),
       meta: {
         title: '訂閱失敗 - carE',
-        requiresAuth: true,
+        // 不需要 requiresAuth，因為從金流頁面跳回時認證狀態可能還沒恢復
       },
     },
     // 維修廠後台頁面（直接路由，透過 navbar 切換）
@@ -175,6 +176,20 @@ const router = createRouter({
       },
     },
   ],
+});
+
+// 路由守衛：檢查需要登入的頁面
+router.beforeEach((to, _from, next) => {
+  const authStore = useAuthStore();
+
+  // 檢查路由是否需要登入
+  if (to.meta.requiresAuth && !authStore.isAuthenticated) {
+    // 未登入，重定向到首頁
+    // 儲存原本要去的路由，登入後可跳回
+    next({ name: 'Home', query: { redirect: to.fullPath } });
+  } else {
+    next();
+  }
 });
 
 export default router;

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -23,15 +23,25 @@ export const useAuthStore = defineStore('auth', () => {
         .eq('user_id', user.value.id)
         .single();
 
+      // 檢查用戶是否有車廠（有車廠則為 garage 角色）
+      const { data: garage } = await supabase
+        .from('garages')
+        .select('id')
+        .eq('owner_id', user.value.id)
+        .maybeSingle();
+      
+      const hasGarage = !!garage;
+      const effectiveRole = hasGarage ? 'garage' : 'member';
+
       if (error) {
         console.error('獲取用戶資料失敗:', error);
         // 如果 profiles table 查詢失敗，fallback 到 user_metadata
-        const { full_name, name, avatar_url, role } = user.value.user_metadata;
+        const { full_name, name, avatar_url } = user.value.user_metadata;
         userStore.login({
           id: user.value.id,
           name: full_name || name || user.value.user_metadata?.name || user.value.email?.split('@')[0] || 'User',
           email: user.value.email || '',
-          role: user.value.user_metadata?.role || 'member',
+          role: effectiveRole,
           avatar: avatar_url,
           nickname: user.value.user_metadata?.nickname,
         });
@@ -41,7 +51,7 @@ export const useAuthStore = defineStore('auth', () => {
           id: profile.id,
           name: profile.name || user.value.email?.split('@')[0] || 'User',
           email: profile.email,
-          role: profile.role || 'member',
+          role: effectiveRole,
           avatar: user.value.user_metadata?.avatar_url || user.value.user_metadata?.picture,
           nickname: profile.nickname,
         });

--- a/frontend/src/views/Garage/GarageOnboarding.vue
+++ b/frontend/src/views/Garage/GarageOnboarding.vue
@@ -2,8 +2,12 @@
 import { ref, reactive, computed, onUnmounted } from 'vue';
 import { useRouter } from 'vue-router';
 import FormInput from '@/components/ui/FormInput.vue';
+import { supabase } from '@/lib/supabase';
+import { useUserStore } from '@/stores/user';
 
 const router = useRouter();
+const userStore = useUserStore();
+const createError = ref<string | null>(null);
 const currentStep = ref(1);
 const isSubmitting = ref(false);
 
@@ -155,10 +159,104 @@ const backToForm = () => {
   didSubmitAttempt.value = false;
 };
 
-// 啟動倒數計時
-const startCountdown = () => {
-  clearCountdownTimer();
+// 建立新車廠到資料庫
+async function createGarage(): Promise<boolean> {
+  console.log('createGarage 函數開始執行');
+  try {
+    // 取得當前登入用戶
+    console.log('取得當前登入用戶...');
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
 
+    console.log('用戶資訊:', user ? `ID: ${user.id}` : '未取得');
+    
+    if (authError || !user) {
+      console.error('未登入或取得用戶失敗:', authError);
+      createError.value = '請先登入再註冊車廠';
+      return false;
+    }
+
+    // 檢查用戶是否已有車廠
+    console.log('檢查用戶是否已有車廠...');
+    const { data: existingGarage, error: checkError } = await supabase
+      .from('garages')
+      .select('id')
+      .eq('owner_id', user.id)
+      .maybeSingle();
+
+    if (checkError) {
+      // 如果查詢失敗（例如 owner_id 欄位不存在），繼續建立新車廠
+      console.warn('檢查車廠時發生錯誤，繼續建立新車廠:', checkError.message);
+    } else if (existingGarage) {
+      console.log('用戶已有車廠，直接跳轉');
+      // 切換為維修廠角色
+      userStore.switchRole('garage');
+      return true; // 已有車廠，視為成功
+    }
+
+    // 從地址中提取城市和區域
+    const address = formData.address.trim();
+    let city = '';
+    let district = '';
+
+    // 嘗試解析台灣地址格式（例如：台北市內湖區...）
+    const cityMatch = address.match(/^(.{2,3}[市縣])/);
+    if (cityMatch && cityMatch[1]) {
+      city = cityMatch[1];
+      const districtMatch = address.substring(city.length).match(/^(.{2,3}[區鄉鎮市])/);
+      if (districtMatch && districtMatch[1]) {
+        district = districtMatch[1];
+      }
+    }
+
+    // 建立新車廠
+    const { data: newGarage, error: insertError } = await supabase
+      .from('garages')
+      .insert({
+        name: formData.garageName.trim(),
+        phone: formData.phone.trim(),
+        address: address,
+        city: city || '未設定',
+        district: district || '',
+        garage_owner_name: formData.ownerName.trim(),
+        tax_id: formData.taxId.trim(),
+        owner_id: user.id,
+      })
+      .select('id')
+      .single();
+
+    if (insertError) {
+      console.error('建立車廠失敗:', insertError);
+      createError.value = '建立車廠失敗，請稍後再試';
+      return false;
+    }
+
+    console.log('車廠建立成功，ID:', newGarage.id);
+    // 切換為維修廠角色
+    userStore.switchRole('garage');
+    return true;
+  } catch (e) {
+    console.error('建立車廠時發生錯誤:', e);
+    createError.value = '系統錯誤，請稍後再試';
+    return false;
+  }
+}
+
+// 啟動倒數計時
+const startCountdown = async () => {
+  clearCountdownTimer();
+  console.log('開始建立車廠流程...');
+
+  // 先建立車廠
+  const success = await createGarage();
+  console.log('建立車廠結果:', success);
+  
+  if (!success) {
+    console.log('建立車廠失敗，顯示失敗畫面');
+    verificationResult.value = 'failure';
+    return;
+  }
+
+  console.log('建立車廠成功，開始倒數計時');
   countdown.value = 3;
 
   countdownTimer = setInterval(() => {

--- a/frontend/src/views/Garage/GarageOnboarding.vue
+++ b/frontend/src/views/Garage/GarageOnboarding.vue
@@ -184,9 +184,12 @@ async function createGarage(): Promise<boolean> {
       .maybeSingle();
 
     if (checkError) {
-      // 如果查詢失敗（例如 owner_id 欄位不存在），繼續建立新車廠
-      console.warn('檢查車廠時發生錯誤，繼續建立新車廠:', checkError.message);
-    } else if (existingGarage) {
+      console.error('檢查現有車廠時發生錯誤:', checkError);
+      createError.value = '無法驗證您的車廠資訊，請稍後再試。';
+      return false;
+    }
+    
+    if (existingGarage) {
       console.log('用戶已有車廠，直接跳轉');
       // 切換為維修廠角色
       userStore.switchRole('garage');

--- a/frontend/src/views/GarageAdmin/GarageAppointments.vue
+++ b/frontend/src/views/GarageAdmin/GarageAppointments.vue
@@ -26,25 +26,13 @@ async function initGarageData() {
       return;
     }
 
-    // 嘗試根據當前用戶查詢 garage (如果有 owner_id 欄位)
-    let { data: garages, error } = await supabase
+    // 根據當前用戶查詢 garage
+    const { data: garages, error } = await supabase
       .from('garages')
       .select('id')
       .eq('owner_id', user.id)
       .limit(1)
       .maybeSingle();
-
-    // 如果 owner_id 欄位不存在，則查詢第一筆資料（開發測試用）
-    if (error && error.message.includes('owner_id')) {
-      console.log('DEV MODE: owner_id 欄位不存在，查詢第一筆資料');
-      const result = await supabase
-        .from('garages')
-        .select('id')
-        .limit(1)
-        .maybeSingle();
-      garages = result.data;
-      error = result.error;
-    }
 
     if (error) {
       console.error('查詢 garage 失敗:', error);
@@ -54,14 +42,14 @@ async function initGarageData() {
     }
 
     if (!garages) {
-      console.warn('找不到 garage 資料');
+      console.warn('找不到車廠資料，請先註冊車廠');
       noGarageError.value = true;
       isLoadingGarage.value = false;
       return;
     }
 
     garageId.value = garages.id;
-    console.log('使用 garage ID:', garageId.value);
+    console.log('使用車廠 ID:', garageId.value);
 
     // 初始化 composables
     if (garageId.value === null) {

--- a/frontend/src/views/GarageAdmin/GarageDashboard.vue
+++ b/frontend/src/views/GarageAdmin/GarageDashboard.vue
@@ -68,25 +68,13 @@ async function initGarageData() {
       return;
     }
 
-    // 嘗試根據當前用戶查詢 garage (如果有 owner_id 欄位)
-    let { data: garages, error } = await supabase
+    // 根據當前用戶查詢 garage
+    const { data: garages, error } = await supabase
       .from('garages')
       .select('id')
       .eq('owner_id', user.id)
       .limit(1)
       .maybeSingle();
-
-    // 如果 owner_id 欄位不存在，則查詢第一筆資料（開發測試用）
-    if (error && error.message.includes('owner_id')) {
-      console.log('DEV MODE: owner_id 欄位不存在，查詢第一筆資料');
-      const result = await supabase
-        .from('garages')
-        .select('id')
-        .limit(1)
-        .maybeSingle();
-      garages = result.data;
-      error = result.error;
-    }
 
     if (error) {
       console.error('查詢 garage 失敗:', error);
@@ -96,14 +84,14 @@ async function initGarageData() {
     }
 
     if (!garages) {
-      console.warn('找不到 garage 資料');
+      console.warn('找不到車廠資料，請先註冊車廠');
       noGarageError.value = true;
       isLoadingGarage.value = false;
       return;
     }
 
     garageId.value = garages.id;
-    console.log('使用 garage ID:', garageId.value);
+    console.log('使用車廠 ID:', garageId.value);
 
     // 確保 garageId 不為 null 才初始化 composable
     if (!garageId.value) {

--- a/frontend/src/views/GarageAdmin/GarageRecords.vue
+++ b/frontend/src/views/GarageAdmin/GarageRecords.vue
@@ -48,25 +48,13 @@ async function initGarageData() {
       return;
     }
 
-    // 嘗試根據當前用戶查詢 garage (如果有 owner_id 欄位)
-    let { data: garages, error } = await supabase
+    // 根據當前用戶查詢 garage
+    const { data: garages, error } = await supabase
       .from('garages')
       .select('id')
       .eq('owner_id', user.id)
       .limit(1)
       .maybeSingle();
-
-    // 如果 owner_id 欄位不存在，則查詢第一筆資料（開發測試用）
-    if (error && error.message.includes('owner_id')) {
-      console.log('DEV MODE: owner_id 欄位不存在，查詢第一筆資料');
-      const result = await supabase
-        .from('garages')
-        .select('id')
-        .limit(1)
-        .maybeSingle();
-      garages = result.data;
-      error = result.error;
-    }
 
     if (error) {
       console.error('查詢 garage 失敗:', error);
@@ -76,7 +64,7 @@ async function initGarageData() {
     }
 
     if (!garages) {
-      console.warn('找不到 garage 資料');
+      console.warn('找不到車廠資料，請先註冊車廠');
       noGarageError.value = true;
       isLoadingGarage.value = false;
       return;

--- a/frontend/src/views/GarageAdmin/GarageSettings.vue
+++ b/frontend/src/views/GarageAdmin/GarageSettings.vue
@@ -35,25 +35,13 @@ async function initGarageData() {
       return;
     }
 
-    // 嘗試根據當前用戶查詢 garage (如果有 owner_id 欄位)
-    let { data: garages, error } = await supabase
+    // 根據當前用戶查詢 garage
+    const { data: garages, error } = await supabase
       .from('garages')
       .select('id')
       .eq('owner_id', user.id)
       .limit(1)
       .maybeSingle();
-
-    // 如果 owner_id 欄位不存在，則查詢第一筆資料（開發測試用）
-    if (error && error.message.includes('owner_id')) {
-      console.log('DEV MODE: owner_id 欄位不存在，查詢第一筆資料');
-      const result = await supabase
-        .from('garages')
-        .select('id')
-        .limit(1)
-        .maybeSingle();
-      garages = result.data;
-      error = result.error;
-    }
 
     console.log('查詢 garage 結果:', { garages, error });
 
@@ -66,7 +54,7 @@ async function initGarageData() {
 
     if (garages) {
       garageId.value = garages.id;
-      console.log('DEV MODE: 使用車廠 ID =', garageId.value);
+      console.log('使用車廠 ID:', garageId.value);
 
       // 初始化 profile API
       if (garageId.value !== null) {
@@ -77,7 +65,8 @@ async function initGarageData() {
         console.log('Profile loaded:', garageProfile);
       }
     } else {
-      console.log('No garage data found, showing empty form');
+      console.log('找不到車廠資料，請先註冊車廠');
+      noGarageError.value = true;
     }
   } catch (e) {
     console.error('初始化失敗:', e);
@@ -183,10 +172,16 @@ async function handleSelectionPlan() {
       <!-- Error State -->
       <div v-else-if="noGarageError" class="flex h-[50vh] w-full items-center justify-center p-6">
       <div class="max-w-md text-center">
-        <h2 class="mb-4 text-2xl font-bold text-[#4A4A45]">找不到任何車廠資料</h2>
+        <h2 class="mb-4 text-2xl font-bold text-[#4A4A45]">尚未註冊車廠</h2>
         <p class="mb-6 text-stone-500">
-          資料庫可能是空的，請先在資料庫建立至少一筆車廠資料。
+          您尚未註冊維修廠，請先完成商家資料填寫。
         </p>
+        <button
+          @click="router.push('/garage/onboarding')"
+          class="rounded-lg bg-[#6B6B5C] px-6 py-2.5 text-sm font-bold text-white shadow-md transition hover:bg-[#5a5a4d]"
+        >
+          前往註冊車廠
+        </button>
       </div>
     </div>
 


### PR DESCRIPTION
### 維修廠後台與金流串接服務全部代碼重構，修復了所有已知問題。

#### 修正
- 拔掉了開發者模式導致只能抓取表格中既有的資料錯誤。
- ONE金流驗證因為維修廠資訊無法抓取的失敗問題。
- Supabase中，profiles的role欄位已棄用不再作為關聯對象。
(最開始沒規劃好導致的問題，上了寶貴的一課)

#### 新增
- 現在garage欄位可以正確註冊新的廠商。
- 現在註冊成為廠商的資料在成功驗證後，資料會正確的自動帶入進後台的編輯資料欄位中，並且與資料庫同步。
(包含地址、統編、程式邏輯判斷對應的uuid...，資料較多，團隊組員請在Supabase自行確認)
- 現在帳號因為有綁定維修廠的關聯關係，登入後會直接切換navbar狀態變更為維修廠的選單。
> 因這些功能有變更需注意，用來測試遊客、一般會員的帳號不要去綁定維修廠。

#### TODO
- 維修廠後台目前有小功能待完善的地方。